### PR TITLE
feat(goreleaser): add archive id and set root ownership for builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,14 +24,17 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - name_template: >-
+  - id: default
+    name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    format: '{{ if eq .Os "windows" }}zip{{ else }}tar.gz{{ end }}'
+    builds_info:
+      group: root
+      owner: root
     files:
       - LICENSE*
       - README.md


### PR DESCRIPTION
- Add explicit "default" id to archives configuration
- Add builds_info section with root group and owner
- Remove conditional format template for OS-specific archive types