### PR TITLE
chore: remove redundant comments and improve code clarity

### DIFF
--- a/cmd/ha-mcp/main.go
+++ b/cmd/ha-mcp/main.go
@@ -60,7 +60,6 @@ func (a *App) setupFlags() {
 	a.rootCmd.PersistentFlags().StringVar(&a.haToken, "ha-token", "", "Home Assistant long-lived access token")
 	a.rootCmd.PersistentFlags().IntVar(&a.port, "port", 0, "MCP server port")
 
-	// Bind flags to viper
 	bindPFlag("homeassistant.url", a.rootCmd.PersistentFlags().Lookup("ha-url"))
 	bindPFlag("homeassistant.token", a.rootCmd.PersistentFlags().Lookup("ha-token"))
 	bindPFlag("server.port", a.rootCmd.PersistentFlags().Lookup("port"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,9 +18,8 @@ var loadEnvOnce sync.Once
 // It is called once before loading configuration.
 func loadDotEnv() {
 	loadEnvOnce.Do(func() {
-		// Try common locations for .env file
-		envFiles := []string{".env", "configs/.env"}
-		for _, f := range envFiles {
+		dotEnvSearchPaths := []string{".env", "configs/.env"}
+		for _, f := range dotEnvSearchPaths {
 			if _, err := os.Stat(f); err == nil {
 				// Load .env but don't override existing environment variables
 				_ = godotenv.Load(f)

--- a/internal/handlers/automations.go
+++ b/internal/handlers/automations.go
@@ -30,8 +30,6 @@ func (h *AutomationHandlers) RegisterTools(registry *mcp.Registry) {
 	registry.RegisterTool(h.toggleAutomationTool(), h.handleToggleAutomation)
 }
 
-// Tool definitions
-
 func (h *AutomationHandlers) listAutomationsTool() mcp.Tool {
 	return mcp.Tool{
 		Name:        "list_automations",
@@ -180,8 +178,6 @@ func (h *AutomationHandlers) toggleAutomationTool() mcp.Tool {
 		},
 	}
 }
-
-// Handler implementations
 
 func (h *AutomationHandlers) handleListAutomations(ctx context.Context, client homeassistant.Client, _ map[string]any) (*mcp.ToolsCallResult, error) {
 	automations, err := client.ListAutomations(ctx)
@@ -396,8 +392,6 @@ func (h *AutomationHandlers) handleToggleAutomation(ctx context.Context, client 
 		Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("Automation '%s' %s successfully", automationID, state))},
 	}, nil
 }
-
-// Helper functions
 
 // getString safely extracts a string value from a map of arguments.
 // It returns an empty string if the key doesn't exist or the value is not a string.

--- a/internal/handlers/entities.go
+++ b/internal/handlers/entities.go
@@ -28,8 +28,6 @@ func (h *EntityHandlers) RegisterTools(registry *mcp.Registry) {
 	registry.RegisterTool(h.listDomainsTool(), h.handleListDomains)
 }
 
-// Tool definitions
-
 func (h *EntityHandlers) getStatesTool() mcp.Tool {
 	return mcp.Tool{
 		Name:        "get_states",
@@ -101,8 +99,6 @@ func (h *EntityHandlers) listDomainsTool() mcp.Tool {
 		},
 	}
 }
-
-// Handler implementations
 
 func (h *EntityHandlers) handleGetStates(ctx context.Context, client homeassistant.Client, args map[string]any) (*mcp.ToolsCallResult, error) {
 	states, err := client.GetStates(ctx)

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -27,8 +27,6 @@ func (h *HelperHandlers) RegisterTools(registry *mcp.Registry) {
 	registry.RegisterTool(h.setHelperValueTool(), h.handleSetHelperValue)
 }
 
-// Tool definitions
-
 func (h *HelperHandlers) listHelpersTool() mcp.Tool {
 	return mcp.Tool{
 		Name:        "list_helpers",
@@ -171,8 +169,6 @@ func (h *HelperHandlers) setHelperValueTool() mcp.Tool {
 		},
 	}
 }
-
-// Handler implementations
 
 func (h *HelperHandlers) handleListHelpers(ctx context.Context, client homeassistant.Client, _ map[string]any) (*mcp.ToolsCallResult, error) {
 	helpers, err := client.ListHelpers(ctx)
@@ -445,7 +441,9 @@ func (h *HelperHandlers) handleSetHelperValue(ctx context.Context, client homeas
 	}, nil
 }
 
-// parseEntityID extracts platform and ID from an entity_id like "input_boolean.my_switch"
+// parseEntityID extracts platform and ID from an entity_id like "input_boolean.my_switch".
+// It iterates through known helper platforms to find a matching prefix.
+// Returns empty strings if the entity_id doesn't match any known helper platform.
 func parseEntityID(entityID string) (platform, id string) {
 	platforms := []string{"input_boolean", "input_number", "input_text", "input_select", "input_datetime"}
 	for _, p := range platforms {

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -45,10 +45,6 @@ func RegisterLovelaceTools(registry *mcp.Registry) {
 	h.RegisterTools(registry)
 }
 
-// Note: RegisterScriptTools is defined in scripts.go
-// Note: RegisterSceneTools is defined in scenes.go
-// Note: RegisterTargetTools is defined in targets.go
-
 // RegisterAllTools registers all available tool handlers with the registry.
 // All handlers use the WebSocket API for communication with Home Assistant.
 func RegisterAllTools(registry *mcp.Registry) {

--- a/internal/homeassistant/factory.go
+++ b/internal/homeassistant/factory.go
@@ -20,8 +20,8 @@ func DefaultClientOptions() ClientOptions {
 	}
 }
 
-// NewClientWithOptions creates a new Home Assistant WebSocket client.
-// This establishes a connection before returning.
+// NewClientWithOptions creates and connects a Home Assistant WebSocket client with custom options.
+// The connection is established before returning; use CloseClient() for cleanup.
 func NewClientWithOptions(ctx context.Context, baseURL, token string, opts ClientOptions) (Client, error) {
 	return NewConnectedWSClient(ctx, baseURL, token, opts.WSConfig)
 }
@@ -52,8 +52,8 @@ func NewConnectedWSClient(ctx context.Context, baseURL, token string, config *WS
 	return NewWSClientImplWithCloser(wsClient), nil
 }
 
-// NewDefaultWSClient creates a WebSocket client with default configuration and connects.
-// This is the primary way to create a Home Assistant client.
+// NewDefaultWSClient creates a connected WebSocket client using default configuration.
+// This is the recommended factory function for most use cases.
 func NewDefaultWSClient(ctx context.Context, baseURL, token string) (Client, error) {
 	return NewConnectedWSClient(ctx, baseURL, token, nil)
 }

--- a/internal/homeassistant/ws_client_impl.go
+++ b/internal/homeassistant/ws_client_impl.go
@@ -117,8 +117,10 @@ func (c *wsClientImpl) CallService(ctx context.Context, domain, service string, 
 	}
 	if result.Result != nil {
 		if err := json.Unmarshal(result.Result, &response); err != nil {
-			// Some service calls don't return entities, return empty slice
-			return []Entity{}, nil //nolint:nilerr // Unmarshal failure is expected for some services
+			// Some service calls (e.g., script.turn_on, automation.trigger) return only
+			// a context without entities. Unmarshal fails because the response structure
+			// differs. This is expected behavior, not an error.
+			return []Entity{}, nil //nolint:nilerr
 		}
 	}
 

--- a/internal/homeassistant/ws_reconnect.go
+++ b/internal/homeassistant/ws_reconnect.go
@@ -122,7 +122,9 @@ func (r *ReconnectManager) WaitForReconnect(ctx context.Context) error {
 	r.attempts++
 	waitDuration := r.currentWait
 
-	// Calculate next wait duration with exponential backoff
+	// Calculate next wait duration with exponential backoff.
+	// We update currentWait BEFORE waiting so that if this goroutine is
+	// interrupted and another caller enters, they will see the increased delay.
 	nextWait := time.Duration(float64(r.currentWait) * r.config.BackoffFactor)
 	if nextWait > r.config.MaxDelay {
 		nextWait = r.config.MaxDelay

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -65,7 +65,8 @@ type Logger struct {
 	level slog.Level
 }
 
-// cleanHandler is a custom slog.Handler that outputs a cleaner log format.
+// cleanHandler implements slog.Handler with a simplified log format:
+// "YYYY-MM-DD HH:MM:SS LEVEL message key=value key=value..."
 type cleanHandler struct {
 	level slog.Level
 	out   io.Writer


### PR DESCRIPTION
- Remove unnecessary section divider comments (Tool definitions, Handler implementations, Helper functions)
- Remove obvious inline comments that don't add value
- Rename envFiles to dotEnvSearchPaths for better clarity
- Expand parseEntityID doc comment with more detail