### PR TITLE
refactor: extract common viper setup and optimize string operations

### DIFF
--- a/internal/handlers/entities.go
+++ b/internal/handlers/entities.go
@@ -231,12 +231,11 @@ func (h *EntityHandlers) handleListDomains(ctx context.Context, client homeassis
 		}, nil
 	}
 
-	// Extract unique domains
+	// Extract unique domains using index lookup for efficiency
 	domainSet := make(map[string]int)
 	for _, state := range states {
-		parts := strings.SplitN(state.EntityID, ".", 2)
-		if len(parts) > 0 {
-			domainSet[parts[0]]++
+		if idx := strings.Index(state.EntityID, "."); idx > 0 {
+			domainSet[state.EntityID[:idx]]++
 		}
 	}
 

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"gitlab.com/zorak1103/ha-mcp/internal/homeassistant"
 	"gitlab.com/zorak1103/ha-mcp/internal/mcp"
@@ -441,15 +442,17 @@ func (h *HelperHandlers) handleSetHelperValue(ctx context.Context, client homeas
 	}, nil
 }
 
+// helperPlatforms defines the known helper platform prefixes.
+var helperPlatforms = []string{"input_boolean", "input_number", "input_text", "input_select", "input_datetime"}
+
 // parseEntityID extracts platform and ID from an entity_id like "input_boolean.my_switch".
 // It iterates through known helper platforms to find a matching prefix.
 // Returns empty strings if the entity_id doesn't match any known helper platform.
 func parseEntityID(entityID string) (platform, id string) {
-	platforms := []string{"input_boolean", "input_number", "input_text", "input_select", "input_datetime"}
-	for _, p := range platforms {
+	for _, p := range helperPlatforms {
 		prefix := p + "."
-		if len(entityID) > len(prefix) && entityID[:len(prefix)] == prefix {
-			return p, entityID[len(prefix):]
+		if strings.HasPrefix(entityID, prefix) {
+			return p, strings.TrimPrefix(entityID, prefix)
 		}
 	}
 	return "", ""

--- a/internal/homeassistant/types.go
+++ b/internal/homeassistant/types.go
@@ -137,12 +137,6 @@ type SceneState struct {
 	Attributes map[string]any `json:"attributes,omitempty"`
 }
 
-// ServiceData represents data passed to a service call.
-type ServiceData struct {
-	EntityID string         `json:"entity_id,omitempty"`
-	Data     map[string]any `json:"data,omitempty"`
-}
-
 // EntityRegistryEntry represents an entry in the Home Assistant entity registry.
 type EntityRegistryEntry struct {
 	EntityID      string `json:"entity_id"`

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -149,6 +149,9 @@ func (r *Registry) ResourceCount() int {
 	return len(r.resources)
 }
 
+// maxDescriptionLen is the maximum length for tool descriptions in log output.
+const maxDescriptionLen = 80
+
 // LogRegisteredTools logs all registered tools at Debug level.
 // This is useful for debugging and verifying that all expected tools are available.
 func (r *Registry) LogRegisteredTools(logger *logging.Logger) {
@@ -169,7 +172,7 @@ func (r *Registry) LogRegisteredTools(logger *logging.Logger) {
 	logger.Debug("Registered MCP tools:")
 	for _, name := range toolNames {
 		entry := r.tools[name]
-		logger.Debug("  - "+name, "description", truncateDescription(entry.tool.Description, 80))
+		logger.Debug("  - "+name, "description", truncateDescription(entry.tool.Description, maxDescriptionLen))
 	}
 
 	// Also log resources if any


### PR DESCRIPTION
- Extract setupViper() function to eliminate duplicate viper configuration code across Load(), LoadWithViper(), and LoadForDisplay()
- Replace strings.SplitN with strings.Index for domain extraction in entity handlers for better performance
- Refactor parseEntityID to use package-level helperPlatforms variable and strings.HasPrefix/TrimPrefix for cleaner code
- Remove redundant comments and improve code consistency