### PR TITLE
feat: Implement DELETE automation/script/scene via REST API

### DIFF
--- a/internal/homeassistant/hybrid_client.go
+++ b/internal/homeassistant/hybrid_client.go
@@ -1,0 +1,292 @@
+// Package homeassistant provides a hybrid client combining WebSocket and REST APIs.
+package homeassistant
+
+import (
+	"context"
+	"time"
+)
+
+// HybridClient combines WebSocket and REST API clients for Home Assistant.
+// It uses WebSocket for most operations but falls back to REST for operations
+// that are not supported via WebSocket (e.g., deleting automations/scripts/scenes).
+type HybridClient struct {
+	ws   *wsClientImpl // WebSocket client for most operations
+	rest *RESTClient   // REST client for delete operations
+}
+
+// NewHybridClient creates a new hybrid client with the given WebSocket and REST clients.
+func NewHybridClient(ws *WSClient, rest *RESTClient) *HybridClient {
+	return &HybridClient{
+		ws:   &wsClientImpl{ws: ws},
+		rest: rest,
+	}
+}
+
+// Ensure HybridClient implements Client interface at compile time.
+var _ Client = (*HybridClient)(nil)
+
+// =============================================================================
+// Core State Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetStates retrieves all entity states.
+func (c *HybridClient) GetStates(ctx context.Context) ([]Entity, error) {
+	return c.ws.GetStates(ctx)
+}
+
+// GetState retrieves the state of a specific entity.
+func (c *HybridClient) GetState(ctx context.Context, entityID string) (*Entity, error) {
+	return c.ws.GetState(ctx, entityID)
+}
+
+// SetState sets the state of an entity.
+func (c *HybridClient) SetState(ctx context.Context, entityID string, state StateUpdate) (*Entity, error) {
+	return c.ws.SetState(ctx, entityID, state)
+}
+
+// GetHistory retrieves historical state changes for an entity.
+func (c *HybridClient) GetHistory(ctx context.Context, entityID string, start, end time.Time) ([][]HistoryEntry, error) {
+	return c.ws.GetHistory(ctx, entityID, start, end)
+}
+
+// CallService calls a Home Assistant service.
+func (c *HybridClient) CallService(ctx context.Context, domain, service string, data map[string]any) ([]Entity, error) {
+	return c.ws.CallService(ctx, domain, service, data)
+}
+
+// =============================================================================
+// Automation Operations (hybrid: WebSocket + REST for delete)
+// =============================================================================
+
+// ListAutomations lists all automations.
+func (c *HybridClient) ListAutomations(ctx context.Context) ([]Automation, error) {
+	return c.ws.ListAutomations(ctx)
+}
+
+// GetAutomation retrieves a specific automation by ID.
+func (c *HybridClient) GetAutomation(ctx context.Context, automationID string) (*Automation, error) {
+	return c.ws.GetAutomation(ctx, automationID)
+}
+
+// CreateAutomation creates a new automation.
+func (c *HybridClient) CreateAutomation(ctx context.Context, config AutomationConfig) error {
+	return c.ws.CreateAutomation(ctx, config)
+}
+
+// UpdateAutomation updates an existing automation.
+func (c *HybridClient) UpdateAutomation(ctx context.Context, automationID string, config AutomationConfig) error {
+	return c.ws.UpdateAutomation(ctx, automationID, config)
+}
+
+// DeleteAutomation deletes an automation using the REST API.
+// The WebSocket API does not support automation deletion reliably.
+func (c *HybridClient) DeleteAutomation(ctx context.Context, automationID string) error {
+	return c.rest.DeleteAutomation(ctx, automationID)
+}
+
+// ToggleAutomation enables or disables an automation.
+func (c *HybridClient) ToggleAutomation(ctx context.Context, entityID string, enabled bool) error {
+	return c.ws.ToggleAutomation(ctx, entityID, enabled)
+}
+
+// =============================================================================
+// Helper Operations (delegated to WebSocket)
+// =============================================================================
+
+// ListHelpers lists all input helpers.
+func (c *HybridClient) ListHelpers(ctx context.Context) ([]Entity, error) {
+	return c.ws.ListHelpers(ctx)
+}
+
+// CreateHelper creates a new input helper.
+func (c *HybridClient) CreateHelper(ctx context.Context, config HelperConfig) error {
+	return c.ws.CreateHelper(ctx, config)
+}
+
+// UpdateHelper updates an existing input helper.
+func (c *HybridClient) UpdateHelper(ctx context.Context, helperID string, config HelperConfig) error {
+	return c.ws.UpdateHelper(ctx, helperID, config)
+}
+
+// DeleteHelper deletes an input helper.
+func (c *HybridClient) DeleteHelper(ctx context.Context, helperID string) error {
+	return c.ws.DeleteHelper(ctx, helperID)
+}
+
+// SetHelperValue sets the value of an input helper.
+func (c *HybridClient) SetHelperValue(ctx context.Context, entityID string, value any) error {
+	return c.ws.SetHelperValue(ctx, entityID, value)
+}
+
+// =============================================================================
+// Script Operations (hybrid: WebSocket + REST for delete)
+// =============================================================================
+
+// ListScripts lists all scripts.
+func (c *HybridClient) ListScripts(ctx context.Context) ([]Entity, error) {
+	return c.ws.ListScripts(ctx)
+}
+
+// GetScript retrieves a specific script by ID.
+func (c *HybridClient) GetScript(ctx context.Context, scriptID string) (*Script, error) {
+	return c.ws.GetScript(ctx, scriptID)
+}
+
+// CreateScript creates a new script.
+func (c *HybridClient) CreateScript(ctx context.Context, scriptID string, config ScriptConfig) error {
+	return c.ws.CreateScript(ctx, scriptID, config)
+}
+
+// UpdateScript updates an existing script.
+func (c *HybridClient) UpdateScript(ctx context.Context, scriptID string, config ScriptConfig) error {
+	return c.ws.UpdateScript(ctx, scriptID, config)
+}
+
+// DeleteScript deletes a script using the REST API.
+// The WebSocket API may not support script deletion reliably.
+func (c *HybridClient) DeleteScript(ctx context.Context, scriptID string) error {
+	return c.rest.DeleteScript(ctx, scriptID)
+}
+
+// =============================================================================
+// Scene Operations (hybrid: WebSocket + REST for delete)
+// =============================================================================
+
+// ListScenes lists all scenes.
+func (c *HybridClient) ListScenes(ctx context.Context) ([]Entity, error) {
+	return c.ws.ListScenes(ctx)
+}
+
+// CreateScene creates a new scene.
+func (c *HybridClient) CreateScene(ctx context.Context, sceneID string, config SceneConfig) error {
+	return c.ws.CreateScene(ctx, sceneID, config)
+}
+
+// UpdateScene updates an existing scene.
+func (c *HybridClient) UpdateScene(ctx context.Context, sceneID string, config SceneConfig) error {
+	return c.ws.UpdateScene(ctx, sceneID, config)
+}
+
+// DeleteScene deletes a scene using the REST API.
+// The WebSocket API may not support scene deletion reliably.
+func (c *HybridClient) DeleteScene(ctx context.Context, sceneID string) error {
+	return c.rest.DeleteScene(ctx, sceneID)
+}
+
+// =============================================================================
+// Registry Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetEntityRegistry retrieves the entity registry.
+func (c *HybridClient) GetEntityRegistry(ctx context.Context) ([]EntityRegistryEntry, error) {
+	return c.ws.GetEntityRegistry(ctx)
+}
+
+// GetDeviceRegistry retrieves the device registry.
+func (c *HybridClient) GetDeviceRegistry(ctx context.Context) ([]DeviceRegistryEntry, error) {
+	return c.ws.GetDeviceRegistry(ctx)
+}
+
+// GetAreaRegistry retrieves the area registry.
+func (c *HybridClient) GetAreaRegistry(ctx context.Context) ([]AreaRegistryEntry, error) {
+	return c.ws.GetAreaRegistry(ctx)
+}
+
+// =============================================================================
+// Media Operations (delegated to WebSocket)
+// =============================================================================
+
+// SignPath generates a signed URL for authenticated access.
+func (c *HybridClient) SignPath(ctx context.Context, path string, expires int) (string, error) {
+	return c.ws.SignPath(ctx, path, expires)
+}
+
+// GetCameraStream gets a camera stream URL.
+func (c *HybridClient) GetCameraStream(ctx context.Context, entityID string) (*StreamInfo, error) {
+	return c.ws.GetCameraStream(ctx, entityID)
+}
+
+// BrowseMedia browses media content.
+func (c *HybridClient) BrowseMedia(ctx context.Context, mediaContentID string) (*MediaBrowseResult, error) {
+	return c.ws.BrowseMedia(ctx, mediaContentID)
+}
+
+// =============================================================================
+// Configuration Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetLovelaceConfig retrieves the Lovelace dashboard configuration.
+func (c *HybridClient) GetLovelaceConfig(ctx context.Context) (map[string]any, error) {
+	return c.ws.GetLovelaceConfig(ctx)
+}
+
+// =============================================================================
+// Statistics Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetStatistics retrieves long-term statistics for entities.
+func (c *HybridClient) GetStatistics(ctx context.Context, statIDs []string, period string) ([]StatisticsResult, error) {
+	return c.ws.GetStatistics(ctx, statIDs, period)
+}
+
+// =============================================================================
+// Target Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetTriggersForTarget retrieves all applicable triggers for the given target.
+func (c *HybridClient) GetTriggersForTarget(ctx context.Context, target Target, expandGroup *bool) ([]string, error) {
+	return c.ws.GetTriggersForTarget(ctx, target, expandGroup)
+}
+
+// GetConditionsForTarget retrieves all applicable conditions for the given target.
+func (c *HybridClient) GetConditionsForTarget(ctx context.Context, target Target, expandGroup *bool) ([]string, error) {
+	return c.ws.GetConditionsForTarget(ctx, target, expandGroup)
+}
+
+// GetServicesForTarget retrieves all applicable services for the given target.
+func (c *HybridClient) GetServicesForTarget(ctx context.Context, target Target, expandGroup *bool) ([]string, error) {
+	return c.ws.GetServicesForTarget(ctx, target, expandGroup)
+}
+
+// ExtractFromTarget extracts entities, devices, and areas from the specified target.
+func (c *HybridClient) ExtractFromTarget(ctx context.Context, target Target, expandGroup *bool) (*ExtractFromTargetResult, error) {
+	return c.ws.ExtractFromTarget(ctx, target, expandGroup)
+}
+
+// =============================================================================
+// Schedule Config Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetScheduleConfig retrieves the full configuration of a schedule helper.
+func (c *HybridClient) GetScheduleConfig(ctx context.Context, scheduleID string) (map[string]any, error) {
+	return c.ws.GetScheduleConfig(ctx, scheduleID)
+}
+
+// =============================================================================
+// HybridClientCloser - implements ClientCloser for proper cleanup
+// =============================================================================
+
+// HybridClientCloser extends HybridClient to implement ClientCloser.
+type HybridClientCloser struct {
+	*HybridClient
+	wsClient *WSClient // Keep reference for closing
+}
+
+// NewHybridClientCloser creates a hybrid client that implements ClientCloser.
+func NewHybridClientCloser(ws *WSClient, rest *RESTClient) *HybridClientCloser {
+	return &HybridClientCloser{
+		HybridClient: NewHybridClient(ws, rest),
+		wsClient:     ws,
+	}
+}
+
+// Close closes the underlying WebSocket connection.
+func (c *HybridClientCloser) Close() error {
+	return c.wsClient.Close()
+}
+
+// Ensure HybridClientCloser implements both Client and ClientCloser.
+var (
+	_ Client       = (*HybridClientCloser)(nil)
+	_ ClientCloser = (*HybridClientCloser)(nil)
+)

--- a/internal/homeassistant/hybrid_client_test.go
+++ b/internal/homeassistant/hybrid_client_test.go
@@ -1,0 +1,202 @@
+package homeassistant
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHybridClient_DeleteAutomation verifies that DeleteAutomation
+// uses the REST client instead of WebSocket.
+func TestHybridClient_DeleteAutomation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		automationID   string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		wantErr        bool
+	}{
+		{
+			name:         "successful deletion via REST",
+			automationID: "test_automation",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				// Verify this is a REST DELETE request
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE method, got %s", r.Method)
+				}
+				expectedPath := "/api/config/automation/config/test_automation"
+				if r.URL.Path != expectedPath {
+					t.Errorf("path = %q, want %q", r.URL.Path, expectedPath)
+				}
+				w.WriteHeader(http.StatusOK)
+			},
+			wantErr: false,
+		},
+		{
+			name:         "REST error propagates",
+			automationID: "nonexistent",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange - Create mock REST server
+			server := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
+			defer server.Close()
+
+			restClient := NewRESTClient(server.URL, "test-token")
+
+			// Create HybridClient with nil WebSocket (we're only testing REST)
+			// Note: In real usage, wsClientImpl would be initialized
+			hybridClient := &HybridClient{
+				ws:   nil, // Not used for DeleteAutomation
+				rest: restClient,
+			}
+
+			// Act
+			err := hybridClient.DeleteAutomation(context.Background(), tt.automationID)
+
+			// Assert
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteAutomation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestHybridClient_DeleteScript verifies that DeleteScript
+// uses the REST client instead of WebSocket.
+func TestHybridClient_DeleteScript(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE method, got %s", r.Method)
+		}
+		expectedPath := "/api/config/script/config/test_script"
+		if r.URL.Path != expectedPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, expectedPath)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	restClient := NewRESTClient(server.URL, "test-token")
+	hybridClient := &HybridClient{
+		ws:   nil,
+		rest: restClient,
+	}
+
+	err := hybridClient.DeleteScript(context.Background(), "test_script")
+
+	if err != nil {
+		t.Errorf("DeleteScript() error = %v, want nil", err)
+	}
+}
+
+// TestHybridClient_DeleteScene verifies that DeleteScene
+// uses the REST client instead of WebSocket.
+func TestHybridClient_DeleteScene(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE method, got %s", r.Method)
+		}
+		expectedPath := "/api/config/scene/config/test_scene"
+		if r.URL.Path != expectedPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, expectedPath)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	restClient := NewRESTClient(server.URL, "test-token")
+	hybridClient := &HybridClient{
+		ws:   nil,
+		rest: restClient,
+	}
+
+	err := hybridClient.DeleteScene(context.Background(), "test_scene")
+
+	if err != nil {
+		t.Errorf("DeleteScene() error = %v, want nil", err)
+	}
+}
+
+// TestNewHybridClient verifies the constructor creates a properly initialized client.
+func TestNewHybridClient(t *testing.T) {
+	t.Parallel()
+
+	// Create mock REST server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	restClient := NewRESTClient(server.URL, "test-token")
+
+	// Create a minimal WSClient for testing (won't connect)
+	wsClient := NewWSClient("ws://localhost:8123", "test-token")
+
+	hybridClient := NewHybridClient(wsClient, restClient)
+
+	// Verify the client was created
+	if hybridClient == nil {
+		t.Fatal("NewHybridClient returned nil")
+	}
+	if hybridClient.ws == nil {
+		t.Error("ws client is nil")
+	}
+	if hybridClient.rest == nil {
+		t.Error("rest client is nil")
+	}
+}
+
+// TestNewHybridClientCloser verifies the closer variant works correctly.
+func TestNewHybridClientCloser(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	restClient := NewRESTClient(server.URL, "test-token")
+	wsClient := NewWSClient("ws://localhost:8123", "test-token")
+
+	hybridCloser := NewHybridClientCloser(wsClient, restClient)
+
+	// Verify it implements both interfaces
+	var _ Client = hybridCloser
+	var _ ClientCloser = hybridCloser
+
+	if hybridCloser == nil {
+		t.Fatal("NewHybridClientCloser returned nil")
+	}
+
+	// Test Close method (should not panic even without connection)
+	// Note: This may error because there's no actual connection,
+	// but it should not panic
+	_ = hybridCloser.Close()
+}
+
+// TestHybridClient_InterfaceCompliance verifies that HybridClient
+// implements the Client interface at compile time.
+func TestHybridClient_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+
+	// This test is primarily for compile-time verification
+	// The var _ declarations in hybrid_client.go also verify this
+	var _ Client = (*HybridClient)(nil)
+	var _ Client = (*HybridClientCloser)(nil)
+	var _ ClientCloser = (*HybridClientCloser)(nil)
+}

--- a/internal/homeassistant/rest_client.go
+++ b/internal/homeassistant/rest_client.go
@@ -1,0 +1,238 @@
+// Package homeassistant provides a REST client for Home Assistant API operations
+// that are not supported via WebSocket.
+package homeassistant
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// noResponseBody is the default message when server returns empty response.
+const noResponseBody = "no response body"
+
+// RESTClient provides REST API operations for Home Assistant.
+// This client is used for operations that are not supported via WebSocket API,
+// such as deleting automations.
+type RESTClient struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// RESTClientConfig configures the REST client.
+type RESTClientConfig struct {
+	// Timeout for HTTP requests (default: 30 seconds)
+	Timeout time.Duration
+}
+
+// DefaultRESTClientConfig returns the default REST client configuration.
+func DefaultRESTClientConfig() RESTClientConfig {
+	return RESTClientConfig{
+		Timeout: 30 * time.Second,
+	}
+}
+
+// NewRESTClient creates a new REST client with default configuration.
+func NewRESTClient(baseURL, token string) *RESTClient {
+	return NewRESTClientWithConfig(baseURL, token, DefaultRESTClientConfig())
+}
+
+// NewRESTClientWithConfig creates a new REST client with custom configuration.
+func NewRESTClientWithConfig(baseURL, token string, config RESTClientConfig) *RESTClient {
+	// Normalize base URL - remove trailing slash and ensure no /api suffix
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	baseURL = strings.TrimSuffix(baseURL, "/api")
+
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	return &RESTClient{
+		baseURL: baseURL,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// DeleteAutomation deletes an automation using the REST API.
+// The WebSocket API does not support automation deletion, so we use REST.
+// Endpoint: DELETE /api/config/automation/config/{automation_id}
+func (c *RESTClient) DeleteAutomation(ctx context.Context, automationID string) error {
+	// Build the URL for automation deletion
+	url := fmt.Sprintf("%s/api/config/automation/config/%s", c.baseURL, automationID)
+
+	// Create the DELETE request
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating delete request: %w", err)
+	}
+
+	// Set authorization header
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing delete request: %w", err)
+	}
+	defer func() {
+		// Drain and close the response body to enable connection reuse
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	// Check response status
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	// Read error response body for better error messages
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if bodyStr == "" {
+		bodyStr = noResponseBody
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("automation not found: %s", automationID),
+		}
+	case http.StatusUnauthorized:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "unauthorized: invalid or expired token",
+		}
+	case http.StatusForbidden:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "forbidden: insufficient permissions to delete automation",
+		}
+	default:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, bodyStr),
+		}
+	}
+}
+
+// DeleteScript deletes a script using the REST API.
+// Endpoint: DELETE /api/config/script/config/{script_id}
+func (c *RESTClient) DeleteScript(ctx context.Context, scriptID string) error {
+	url := fmt.Sprintf("%s/api/config/script/config/%s", c.baseURL, scriptID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating delete request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing delete request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if bodyStr == "" {
+		bodyStr = noResponseBody
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("script not found: %s", scriptID),
+		}
+	case http.StatusUnauthorized:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "unauthorized: invalid or expired token",
+		}
+	case http.StatusForbidden:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "forbidden: insufficient permissions to delete script",
+		}
+	default:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, bodyStr),
+		}
+	}
+}
+
+// DeleteScene deletes a scene using the REST API.
+// Endpoint: DELETE /api/config/scene/config/{scene_id}
+func (c *RESTClient) DeleteScene(ctx context.Context, sceneID string) error {
+	url := fmt.Sprintf("%s/api/config/scene/config/%s", c.baseURL, sceneID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating delete request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing delete request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if bodyStr == "" {
+		bodyStr = noResponseBody
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("scene not found: %s", sceneID),
+		}
+	case http.StatusUnauthorized:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "unauthorized: invalid or expired token",
+		}
+	case http.StatusForbidden:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    "forbidden: insufficient permissions to delete scene",
+		}
+	default:
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, bodyStr),
+		}
+	}
+}

--- a/internal/homeassistant/rest_client_test.go
+++ b/internal/homeassistant/rest_client_test.go
@@ -1,0 +1,398 @@
+package homeassistant
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewRESTClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		baseURL         string
+		token           string
+		wantBaseURL     string
+		wantTokenPrefix string
+	}{
+		{
+			name:            "standard URL",
+			baseURL:         "http://localhost:8123",
+			token:           "test-token",
+			wantBaseURL:     "http://localhost:8123",
+			wantTokenPrefix: "test-token",
+		},
+		{
+			name:            "URL with trailing slash",
+			baseURL:         "http://localhost:8123/",
+			token:           "my-token",
+			wantBaseURL:     "http://localhost:8123",
+			wantTokenPrefix: "my-token",
+		},
+		{
+			name:            "URL with /api suffix",
+			baseURL:         "http://localhost:8123/api",
+			token:           "another-token",
+			wantBaseURL:     "http://localhost:8123",
+			wantTokenPrefix: "another-token",
+		},
+		{
+			name:            "URL with /api/ suffix",
+			baseURL:         "http://localhost:8123/api/",
+			token:           "token123",
+			wantBaseURL:     "http://localhost:8123",
+			wantTokenPrefix: "token123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := NewRESTClient(tt.baseURL, tt.token)
+
+			if client.baseURL != tt.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", client.baseURL, tt.wantBaseURL)
+			}
+			if client.token != tt.wantTokenPrefix {
+				t.Errorf("token = %q, want %q", client.token, tt.wantTokenPrefix)
+			}
+			if client.httpClient == nil {
+				t.Error("httpClient is nil")
+			}
+		})
+	}
+}
+
+func TestNewRESTClientWithConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      RESTClientConfig
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "default timeout when zero",
+			config:      RESTClientConfig{Timeout: 0},
+			wantTimeout: 30 * time.Second,
+		},
+		{
+			name:        "custom timeout",
+			config:      RESTClientConfig{Timeout: 10 * time.Second},
+			wantTimeout: 10 * time.Second,
+		},
+		{
+			name:        "longer timeout",
+			config:      RESTClientConfig{Timeout: 60 * time.Second},
+			wantTimeout: 60 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := NewRESTClientWithConfig("http://localhost:8123", "token", tt.config)
+
+			if client.httpClient.Timeout != tt.wantTimeout {
+				t.Errorf("timeout = %v, want %v", client.httpClient.Timeout, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestRESTClient_DeleteAutomation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		automationID   string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		wantErr        bool
+		wantErrType    string
+		wantErrMsg     string
+	}{
+		{
+			name:         "successful deletion with 200",
+			automationID: "test_automation",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			wantErr: false,
+		},
+		{
+			name:         "successful deletion with 204",
+			automationID: "another_automation",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			wantErr: false,
+		},
+		{
+			name:         "automation not found",
+			automationID: "nonexistent",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr:     true,
+			wantErrType: "*homeassistant.APIError",
+			wantErrMsg:  "automation not found: nonexistent",
+		},
+		{
+			name:         "unauthorized",
+			automationID: "test",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantErr:     true,
+			wantErrType: "*homeassistant.APIError",
+			wantErrMsg:  "unauthorized: invalid or expired token",
+		},
+		{
+			name:         "forbidden",
+			automationID: "test",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			wantErr:     true,
+			wantErrType: "*homeassistant.APIError",
+			wantErrMsg:  "forbidden: insufficient permissions to delete automation",
+		},
+		{
+			name:         "server error",
+			automationID: "test",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("internal error"))
+			},
+			wantErr:     true,
+			wantErrType: "*homeassistant.APIError",
+			wantErrMsg:  "unexpected status 500: internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			var capturedRequest *http.Request
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedRequest = r
+				tt.serverResponse(w, r)
+			}))
+			defer server.Close()
+
+			client := NewRESTClient(server.URL, "test-token")
+			ctx := context.Background()
+
+			// Act
+			err := client.DeleteAutomation(ctx, tt.automationID)
+
+			// Assert
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteAutomation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Verify request details
+			if capturedRequest == nil {
+				t.Fatal("no request was captured")
+			}
+			if capturedRequest.Method != http.MethodDelete {
+				t.Errorf("method = %q, want %q", capturedRequest.Method, http.MethodDelete)
+			}
+			expectedPath := "/api/config/automation/config/" + tt.automationID
+			if capturedRequest.URL.Path != expectedPath {
+				t.Errorf("path = %q, want %q", capturedRequest.URL.Path, expectedPath)
+			}
+			if auth := capturedRequest.Header.Get("Authorization"); auth != "Bearer test-token" {
+				t.Errorf("Authorization = %q, want %q", auth, "Bearer test-token")
+			}
+
+			if tt.wantErr && err != nil {
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) {
+					t.Errorf("error type = %T, want %s", err, tt.wantErrType)
+					return
+				}
+				if apiErr.Message != tt.wantErrMsg {
+					t.Errorf("error message = %q, want %q", apiErr.Message, tt.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestRESTClient_DeleteScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		scriptID       string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		wantErr        bool
+		wantErrMsg     string
+	}{
+		{
+			name:     "successful deletion",
+			scriptID: "test_script",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			wantErr: false,
+		},
+		{
+			name:     "script not found",
+			scriptID: "nonexistent",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr:    true,
+			wantErrMsg: "script not found: nonexistent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify endpoint path
+				expectedPath := "/api/config/script/config/" + tt.scriptID
+				if r.URL.Path != expectedPath {
+					t.Errorf("path = %q, want %q", r.URL.Path, expectedPath)
+				}
+				tt.serverResponse(w, r)
+			}))
+			defer server.Close()
+
+			client := NewRESTClient(server.URL, "test-token")
+			err := client.DeleteScript(context.Background(), tt.scriptID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteScript() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil {
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) {
+					t.Errorf("error type = %T, want *APIError", err)
+					return
+				}
+				if apiErr.Message != tt.wantErrMsg {
+					t.Errorf("error message = %q, want %q", apiErr.Message, tt.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestRESTClient_DeleteScene(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		sceneID        string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		wantErr        bool
+		wantErrMsg     string
+	}{
+		{
+			name:    "successful deletion",
+			sceneID: "test_scene",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "scene not found",
+			sceneID: "nonexistent",
+			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr:    true,
+			wantErrMsg: "scene not found: nonexistent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedPath := "/api/config/scene/config/" + tt.sceneID
+				if r.URL.Path != expectedPath {
+					t.Errorf("path = %q, want %q", r.URL.Path, expectedPath)
+				}
+				tt.serverResponse(w, r)
+			}))
+			defer server.Close()
+
+			client := NewRESTClient(server.URL, "test-token")
+			err := client.DeleteScene(context.Background(), tt.sceneID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteScene() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil {
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) {
+					t.Errorf("error type = %T, want *APIError", err)
+					return
+				}
+				if apiErr.Message != tt.wantErrMsg {
+					t.Errorf("error message = %q, want %q", apiErr.Message, tt.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestRESTClient_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewRESTClient(server.URL, "test-token")
+
+	// Create context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.DeleteAutomation(ctx, "test")
+
+	if err == nil {
+		t.Error("expected error for cancelled context, got nil")
+	}
+}
+
+func TestDefaultRESTClientConfig(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultRESTClientConfig()
+
+	want := RESTClientConfig{
+		Timeout: 30 * time.Second,
+	}
+
+	if diff := cmp.Diff(want, config); diff != "" {
+		t.Errorf("DefaultRESTClientConfig() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Issue #11: DELETE automation/script/scene via REST API.

### Problem

The WebSocket API does not reliably support deletion of automations, scripts, and scenes. The `config/automation/delete` WebSocket command was not working.

### Solution

Introduced a hybrid client architecture that uses:
- **WebSocket API** for most operations (read, create, update)
- **REST API** for delete operations

### Changes

**New Files:**
- `internal/homeassistant/rest_client.go` - REST API client for delete operations
- `internal/homeassistant/rest_client_test.go` - Unit tests (13 tests)
- `internal/homeassistant/hybrid_client.go` - Hybrid client combining WebSocket + REST
- `internal/homeassistant/hybrid_client_test.go` - Unit tests (6 tests)

**Modified Files:**
- `internal/homeassistant/factory.go` - Now creates HybridClient instead of pure WebSocket client

### API Endpoints (REST)

- `DELETE /api/config/automation/config/{automation_id}`
- `DELETE /api/config/script/config/{script_id}`
- `DELETE /api/config/scene/config/{scene_id}`

### Testing

- All tests pass
- golangci-lint: 0 issues
- Backward compatible (no changes to Client interface)

Closes #11