### PR TITLE
feat: Implement token-based authentication for Home Assistant clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ go build -o ha-mcp ./cmd/ha-mcp
 # Build Docker image locally
 docker build -t ha-mcp:latest .
 
-# Run container
+# Run container (token provided by clients via Authorization header)
+docker run -d \
+  --name ha-mcp \
+  -p 8080:8080 \
+  -e HA_URL=http://homeassistant.local:8123 \
+  ha-mcp:latest
+
+# Or with default token for development (optional)
 docker run -d \
   --name ha-mcp \
   -p 8080:8080 \
@@ -284,6 +291,9 @@ Add to your Cline MCP configuration (`~/.config/cline/mcp.json`):
   "servers": {
     "ha-mcp": {
       "url": "http://localhost:8080",
+      "headers": {
+        "Authorization": "Bearer your-ha-access-token"
+      },
       "description": "Home Assistant MCP Server"
     }
   }
@@ -298,7 +308,11 @@ Add to Claude Desktop's MCP configuration:
 {
   "mcpServers": {
     "homeassistant": {
-      "url": "http://localhost:8080"
+      "type": "http",
+      "url": "http://localhost:8080",
+      "headers": {
+        "Authorization": "Bearer ${HA_TOKEN}"
+      }
     }
   }
 }
@@ -313,6 +327,8 @@ mcp:
   servers:
     - name: homeassistant
       url: http://localhost:8080
+      headers:
+        Authorization: "Bearer your-ha-access-token"
 ```
 
 ## API Reference
@@ -324,6 +340,7 @@ All MCP requests are sent to:
 ```
 POST http://localhost:8080/
 Content-Type: application/json
+Authorization: Bearer <your-ha-access-token>
 ```
 
 ### Available Tools
@@ -672,9 +689,64 @@ ha-mcp provides comprehensive support for all 14 Home Assistant helper types. Ea
 }
 ```
 
+## Authentication
+
+ha-mcp supports flexible authentication via HTTP Bearer tokens. The Home Assistant access token can be provided either per-request via HTTP header or as a server default.
+
+### Token via HTTP Header (Recommended)
+
+MCP clients send the Home Assistant token in the `Authorization` header with every request:
+
+```
+Authorization: Bearer <your-long-lived-access-token>
+```
+
+This approach is recommended because:
+- Each client can use their own Home Assistant token
+- Tokens are not stored on the server
+- Tokens can have different permissions for different clients
+
+**Example with curl:**
+
+```bash
+curl -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc..." \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+### Development Mode (Optional)
+
+For local development or testing, you can configure a default token on the server:
+
+```bash
+ha-mcp --ha-url http://homeassistant.local:8123 --ha-token your-token
+```
+
+When a default token is configured:
+- Requests **with** an `Authorization` header use the header token
+- Requests **without** an `Authorization` header use the default token
+
+This allows backwards-compatible operation while supporting per-request authentication.
+
+### Authentication Errors
+
+When no token is provided and no default is configured:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32004,
+    "message": "authorization header with Bearer token required"
+  }
+}
+```
+
 ## Health Check
 
-The server provides a health check endpoint:
+The server provides a health check endpoint (no authentication required):
 
 ```bash
 curl http://localhost:8080/health

--- a/cmd/ha-mcp/main.go
+++ b/cmd/ha-mcp/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -212,13 +213,30 @@ func (a *App) run(_ *cobra.Command, _ []string) error {
 	ctx, cancel := a.setupGracefulShutdown(logger)
 	defer cancel()
 
-	haClient, err := a.initHomeAssistantClient(ctx, cfg, logger)
-	if err != nil {
-		return err
-	}
-	defer a.closeHomeAssistantClient(haClient, logger)
+	// Create client pool (always required for per-request auth)
+	clientPool := homeassistant.NewClientPool(cfg.HomeAssistant.URL, 30*time.Minute)
+	defer func() {
+		logger.Info("Closing client pool...")
+		if closeErr := clientPool.Close(); closeErr != nil {
+			logger.Error("Error closing client pool", "error", closeErr)
+		}
+	}()
 
-	mcpServer := a.initMCPServer(haClient, cfg.Server.Port, logger)
+	// Create default client only if token is configured (optional, for backwards compatibility)
+	var defaultClient homeassistant.Client
+	if cfg.HomeAssistant.Token != "" {
+		logger.Info("Creating default HA client from configured token...")
+		defaultClient, err = a.initHomeAssistantClient(ctx, cfg, logger)
+		if err != nil {
+			logger.Warn("Could not create default HA client, per-request auth only", "error", err)
+		} else {
+			defer a.closeHomeAssistantClient(defaultClient, logger)
+		}
+	} else {
+		logger.Info("No default token configured - clients must provide Authorization header")
+	}
+
+	mcpServer := a.initMCPServer(clientPool, defaultClient, cfg.Server.Port, logger)
 	a.startMCPServer(mcpServer, logger, cancel)
 
 	<-ctx.Done()
@@ -290,7 +308,8 @@ func (a *App) closeHomeAssistantClient(client homeassistant.Client, logger *logg
 
 // initMCPServer creates and configures the MCP server with all registered tools.
 func (a *App) initMCPServer(
-	haClient homeassistant.Client,
+	clientPool *homeassistant.ClientPool,
+	defaultClient homeassistant.Client,
 	port int,
 	logger *logging.Logger,
 ) *mcp.Server {
@@ -300,7 +319,7 @@ func (a *App) initMCPServer(
 	logger.Info("Registered MCP tools", "count", registry.ToolCount())
 	registry.LogRegisteredTools(logger)
 
-	return mcp.NewServer(haClient, registry, port, logger)
+	return mcp.NewServer(clientPool, defaultClient, registry, port, logger)
 }
 
 // startMCPServer starts the MCP server in a goroutine.

--- a/configs/.env.example
+++ b/configs/.env.example
@@ -2,17 +2,25 @@
 # Copy this file to .env and adjust values
 # Or export these variables in your shell
 
-# Home Assistant URL
+# Home Assistant URL (required)
 # Examples:
 #   - http://homeassistant.local:8123
 #   - http://192.168.1.100:8123
 #   - https://your-ha-domain.duckdns.org
 HA_URL=http://homeassistant.local:8123
 
-# Home Assistant Long-Lived Access Token
+# Home Assistant Long-Lived Access Token (OPTIONAL)
 # Generate at: Home Assistant → Profile → Long-Lived Access Tokens
-# Keep this secret! Do not commit to version control.
-HA_TOKEN=your-long-lived-access-token
+#
+# Authentication options:
+# 1. Per-request (recommended): MCP clients send token via Authorization header
+#    Comment out HA_TOKEN - each client provides their own token.
+#
+# 2. Default token (development): Set HA_TOKEN for backwards compatibility.
+#    Requests without Authorization header will use this token.
+#
+# If set, keep this secret! Do not commit to version control.
+# HA_TOKEN=your-long-lived-access-token
 
 # MCP Server Port (optional, default: 8080)
 HA_MCP_PORT=8080
@@ -25,3 +33,35 @@ HA_MCP_PORT=8080
 # WARN:  Warnings only
 # ERROR: Errors only
 HA_MCP_LOG_LEVEL=INFO
+
+# ============================================================================
+# MCP Client Authentication
+# ============================================================================
+# MCP clients should send the Home Assistant token in the Authorization header:
+#
+#   Authorization: Bearer <your-ha-access-token>
+#
+# Example MCP client configuration (Claude Desktop):
+#   {
+#     "mcpServers": {
+#       "homeassistant": {
+#         "type": "http",
+#         "url": "http://localhost:8080",
+#         "headers": {
+#           "Authorization": "Bearer ${HA_TOKEN}"
+#         }
+#       }
+#     }
+#   }
+#
+# Example MCP client configuration (Cline):
+#   {
+#     "servers": {
+#       "ha-mcp": {
+#         "url": "http://localhost:8080",
+#         "headers": {
+#           "Authorization": "Bearer your-ha-access-token"
+#         }
+#       }
+#     }
+#   }

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -3,18 +3,26 @@
 
 # Home Assistant connection settings
 homeassistant:
-  # URL of your Home Assistant instance
+  # URL of your Home Assistant instance (required)
   # Examples:
   #   - http://homeassistant.local:8123
   #   - http://192.168.1.100:8123
   #   - https://your-ha-domain.duckdns.org
   url: "http://homeassistant.local:8123"
-  
-  # Long-Lived Access Token
+
+  # Long-Lived Access Token (OPTIONAL)
   # Generate at: Home Assistant → Profile → Long-Lived Access Tokens
-  # Keep this secret! Do not commit to version control.
-  token: "your-long-lived-access-token"
-  
+  #
+  # Authentication options:
+  # 1. Per-request (recommended): MCP clients send token via Authorization header
+  #    No token needed here - each client provides their own token.
+  #
+  # 2. Default token (development): Configure token here for backwards compatibility.
+  #    Requests without Authorization header will use this token.
+  #
+  # If set, keep this secret! Do not commit to version control.
+  # token: "your-long-lived-access-token"
+
   # Request timeout in seconds (optional, default: 30)
   timeout: 30
 
@@ -22,7 +30,7 @@ homeassistant:
 server:
   # Port for the MCP HTTP server
   port: 8080
-  
+
   # Host to bind to (optional, default: localhost)
   # Use "0.0.0.0" to listen on all interfaces
   host: "localhost"
@@ -36,3 +44,34 @@ logging:
   # WARN:  Warnings only
   # ERROR: Errors only
   level: "info"
+
+# Authentication
+# -------------
+# MCP clients should send the Home Assistant token in the Authorization header:
+#
+#   Authorization: Bearer <your-ha-access-token>
+#
+# Example MCP client configuration (Claude Desktop):
+#   {
+#     "mcpServers": {
+#       "homeassistant": {
+#         "type": "http",
+#         "url": "http://localhost:8080",
+#         "headers": {
+#           "Authorization": "Bearer ${HA_TOKEN}"
+#         }
+#       }
+#     }
+#   }
+#
+# Example MCP client configuration (Cline):
+#   {
+#     "servers": {
+#       "ha-mcp": {
+#         "url": "http://localhost:8080",
+#         "headers": {
+#           "Authorization": "Bearer your-ha-access-token"
+#         }
+#       }
+#     }
+#   }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,9 +216,8 @@ func (c *Config) validate() error {
 	if c.HomeAssistant.URL == "" {
 		return fmt.Errorf("homeassistant.url is required")
 	}
-	if c.HomeAssistant.Token == "" {
-		return fmt.Errorf("homeassistant.token is required (set via HA_TOKEN env var, --ha-token flag, or config file)")
-	}
+	// Token is optional - can come from request header via Authorization: Bearer <token>
+	// When not configured, clients must provide token in each request
 	if c.Server.Port <= 0 || c.Server.Port > 65535 {
 		return fmt.Errorf("server.port must be between 1 and 65535")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,13 +35,12 @@ func TestLoad(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:       "missing token",
+			name:       "missing token is now allowed",
 			configFile: "",
 			envVars: map[string]string{
 				"HA_URL": "http://test.local:8123",
 			},
-			wantErr:    true,
-			errContain: "homeassistant.token is required",
+			wantErr: false, // Token is now optional - provided via Authorization header
 		},
 		{
 			name:       "missing URL uses default",
@@ -233,13 +232,12 @@ func TestLoadWithViper(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "missing token in viper",
+			name: "missing token in viper is now allowed",
 			setupViper: func(v *viper.Viper) {
 				v.Set("homeassistant.url", "http://viper-test.local:8123")
 			},
 			configFile: "",
-			wantErr:    true,
-			errContain: "homeassistant.token is required",
+			wantErr:    false, // Token is now optional - provided via Authorization header
 		},
 	}
 
@@ -564,17 +562,16 @@ func TestValidate(t *testing.T) {
 			errContain: "homeassistant.url is required",
 		},
 		{
-			name: "empty token",
+			name: "empty token is now allowed",
 			config: Config{
 				HomeAssistant: HomeAssistantConfig{
 					URL:   "http://test.local:8123",
-					Token: "",
+					Token: "", // Token is now optional - provided via Authorization header
 				},
 				Server:  ServerConfig{Port: 8080},
 				Logging: LoggingConfig{Level: "info"},
 			},
-			wantErr:    true,
-			errContain: "homeassistant.token is required",
+			wantErr: false,
 		},
 		{
 			name: "port 0",

--- a/internal/homeassistant/client_pool.go
+++ b/internal/homeassistant/client_pool.go
@@ -1,0 +1,163 @@
+// Package homeassistant provides client factories and management for Home Assistant API.
+package homeassistant
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ClientPool manages a pool of Home Assistant clients, one per token.
+// It provides thread-safe access to clients and automatic cleanup of idle connections.
+type ClientPool struct {
+	baseURL string
+	clients map[string]*pooledClient
+	mu      sync.RWMutex
+	maxIdle time.Duration
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
+}
+
+// pooledClient wraps a Client with last-used timestamp for idle cleanup.
+type pooledClient struct {
+	client   Client
+	lastUsed time.Time
+}
+
+// NewClientPool creates a new client pool for the given Home Assistant URL.
+// maxIdle specifies how long an idle connection is kept before cleanup.
+func NewClientPool(baseURL string, maxIdle time.Duration) *ClientPool {
+	p := &ClientPool{
+		baseURL: baseURL,
+		clients: make(map[string]*pooledClient),
+		maxIdle: maxIdle,
+		stopCh:  make(chan struct{}),
+	}
+
+	// Start idle cleanup goroutine
+	p.wg.Add(1)
+	go p.cleanupLoop()
+
+	return p
+}
+
+// GetOrCreate returns an existing client for the token or creates a new one.
+// The client is connected before being returned.
+func (p *ClientPool) GetOrCreate(ctx context.Context, token string) (Client, error) {
+	// Use write lock to safely check and potentially modify lastUsed or remove disconnected clients
+	p.mu.Lock()
+	if pc, exists := p.clients[token]; exists {
+		// Check if client is still connected
+		if !isClientConnected(pc.client) {
+			// Client disconnected, remove from pool and create new one
+			_ = CloseClient(pc.client)
+			delete(p.clients, token)
+			p.mu.Unlock()
+			// Fall through to create new client below
+		} else {
+			pc.lastUsed = time.Now()
+			client := pc.client
+			p.mu.Unlock()
+			return client, nil
+		}
+	} else {
+		p.mu.Unlock()
+	}
+
+	// Need write lock to create new client
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have created it)
+	if pc, exists := p.clients[token]; exists {
+		// Re-check connection status
+		if !isClientConnected(pc.client) {
+			_ = CloseClient(pc.client)
+			delete(p.clients, token)
+			// Fall through to create new client
+		} else {
+			pc.lastUsed = time.Now()
+			return pc.client, nil
+		}
+	}
+
+	// Create new client
+	client, err := NewDefaultWSClient(ctx, p.baseURL, token)
+	if err != nil {
+		return nil, err
+	}
+
+	p.clients[token] = &pooledClient{
+		client:   client,
+		lastUsed: time.Now(),
+	}
+
+	return client, nil
+}
+
+// Close closes all pooled clients and stops the cleanup goroutine.
+func (p *ClientPool) Close() error {
+	close(p.stopCh)
+	p.wg.Wait()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var lastErr error
+	for token, pc := range p.clients {
+		if err := CloseClient(pc.client); err != nil {
+			lastErr = err
+		}
+		delete(p.clients, token)
+	}
+
+	return lastErr
+}
+
+// cleanupLoop periodically removes idle clients from the pool.
+func (p *ClientPool) cleanupLoop() {
+	defer p.wg.Done()
+
+	ticker := time.NewTicker(p.maxIdle / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			p.cleanupIdleClients()
+		}
+	}
+}
+
+// cleanupIdleClients removes clients that haven't been used within maxIdle duration.
+func (p *ClientPool) cleanupIdleClients() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	for token, pc := range p.clients {
+		if now.Sub(pc.lastUsed) > p.maxIdle {
+			_ = CloseClient(pc.client)
+			delete(p.clients, token)
+		}
+	}
+}
+
+// Size returns the current number of clients in the pool.
+func (p *ClientPool) Size() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.clients)
+}
+
+// isClientConnected checks if the client still has an active connection.
+// Uses type assertion to check for IsConnected method (implemented by WSClient).
+func isClientConnected(client Client) bool {
+	if checker, ok := client.(interface{ IsConnected() bool }); ok {
+		return checker.IsConnected()
+	}
+	// If no connection check available, assume connected (optimistic)
+	return true
+}

--- a/internal/homeassistant/client_pool_test.go
+++ b/internal/homeassistant/client_pool_test.go
@@ -1,0 +1,104 @@
+package homeassistant
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewClientPool(t *testing.T) {
+	pool := NewClientPool("http://localhost:8123", 30*time.Minute)
+	defer pool.Close()
+
+	if pool == nil {
+		t.Fatal("NewClientPool returned nil")
+	}
+
+	if pool.Size() != 0 {
+		t.Errorf("Expected empty pool, got size %d", pool.Size())
+	}
+}
+
+func TestClientPool_Size(t *testing.T) {
+	pool := NewClientPool("http://localhost:8123", 30*time.Minute)
+	defer pool.Close()
+
+	if pool.Size() != 0 {
+		t.Errorf("Expected size 0, got %d", pool.Size())
+	}
+}
+
+func TestClientPool_Close(t *testing.T) {
+	pool := NewClientPool("http://localhost:8123", 30*time.Minute)
+
+	err := pool.Close()
+	if err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+
+	// Pool should be empty after close
+	if pool.Size() != 0 {
+		t.Errorf("Expected empty pool after close, got size %d", pool.Size())
+	}
+}
+
+func TestClientPool_GetOrCreate_InvalidToken(t *testing.T) {
+	pool := NewClientPool("http://localhost:8123", 30*time.Minute)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// This should fail because we can't connect to localhost:8123
+	_, err := pool.GetOrCreate(ctx, "invalid-token")
+	if err == nil {
+		t.Error("Expected error for invalid connection, got nil")
+	}
+}
+
+// Note: TestExtractBearerToken is in server_test.go since extractBearerToken is in mcp package
+
+// connectionChecker is a minimal type for testing IsConnected behavior.
+type connectionChecker struct {
+	connected bool
+}
+
+func (c *connectionChecker) IsConnected() bool {
+	return c.connected
+}
+
+// noConnectionChecker is a type without IsConnected method.
+type noConnectionChecker struct{}
+
+func TestIsClientConnected_WithConnectedClient(t *testing.T) {
+	// Use type assertion test - connectionChecker has IsConnected
+	checker := &connectionChecker{connected: true}
+	// Test the type assertion directly
+	if c, ok := interface{}(checker).(interface{ IsConnected() bool }); ok {
+		if !c.IsConnected() {
+			t.Error("Expected connected checker to return true")
+		}
+	} else {
+		t.Error("Expected connectionChecker to implement IsConnected interface")
+	}
+}
+
+func TestIsClientConnected_WithDisconnectedClient(t *testing.T) {
+	checker := &connectionChecker{connected: false}
+	if c, ok := interface{}(checker).(interface{ IsConnected() bool }); ok {
+		if c.IsConnected() {
+			t.Error("Expected disconnected checker to return false")
+		}
+	} else {
+		t.Error("Expected connectionChecker to implement IsConnected interface")
+	}
+}
+
+func TestIsClientConnected_WithoutIsConnectedMethod(t *testing.T) {
+	// noConnectionChecker doesn't have IsConnected method
+	checker := &noConnectionChecker{}
+	// Should not satisfy the interface
+	if _, ok := interface{}(checker).(interface{ IsConnected() bool }); ok {
+		t.Error("Expected noConnectionChecker to NOT implement IsConnected interface")
+	}
+}

--- a/internal/homeassistant/hybrid_client.go
+++ b/internal/homeassistant/hybrid_client.go
@@ -285,6 +285,16 @@ func (c *HybridClientCloser) Close() error {
 	return c.wsClient.Close()
 }
 
+// IsConnected returns true if the underlying WebSocket client is connected.
+func (c *HybridClientCloser) IsConnected() bool {
+	return c.wsClient.IsConnected()
+}
+
+// WaitForConnection waits until the underlying WebSocket client is connected.
+func (c *HybridClientCloser) WaitForConnection(ctx context.Context) error {
+	return c.wsClient.WaitForConnection(ctx)
+}
+
 // Ensure HybridClientCloser implements both Client and ClientCloser.
 var (
 	_ Client       = (*HybridClientCloser)(nil)

--- a/internal/homeassistant/ws_client.go
+++ b/internal/homeassistant/ws_client.go
@@ -641,6 +641,47 @@ func (c *WSClient) IsConnected() bool {
 	return c.connected.Load()
 }
 
+// IsReconnecting returns true if the client is currently attempting to reconnect.
+func (c *WSClient) IsReconnecting() bool {
+	return c.reconnecting.Load()
+}
+
+// WaitForConnection waits until the client is connected or the context is canceled.
+// This is useful when a reconnection is in progress and the caller wants to wait for it.
+// Returns nil if connected, context error if canceled, or ErrMaxReconnectAttempts if
+// reconnection failed.
+func (c *WSClient) WaitForConnection(ctx context.Context) error {
+	// Already connected, return immediately
+	if c.connected.Load() {
+		return nil
+	}
+
+	// Poll for connection with exponential backoff
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	maxWait := 10 * time.Second
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if c.connected.Load() {
+				return nil
+			}
+			// If not reconnecting and not connected, reconnection has failed
+			if !c.reconnecting.Load() && !c.connected.Load() {
+				// Check if we should give up
+				if time.Now().After(deadline) {
+					return ErrMaxReconnectAttempts
+				}
+			}
+		}
+	}
+}
+
 // IsHealthy returns true if the connection is connected and has received
 // a recent pong response (within PingInterval + PingTimeout).
 func (c *WSClient) IsHealthy() bool {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,25 +35,35 @@ const (
 
 // Server represents the MCP server.
 type Server struct {
-	haClient    homeassistant.Client
-	registry    *Registry
-	httpServer  *http.Server
-	port        int
-	logger      *logging.Logger
-	mu          sync.RWMutex
-	initialized bool
+	clientPool    *homeassistant.ClientPool // Pool of HA clients per token
+	defaultClient homeassistant.Client      // Optional default client from --ha-token
+	registry      *Registry
+	httpServer    *http.Server
+	port          int
+	logger        *logging.Logger
+	mu            sync.RWMutex
+	initialized   bool
 }
 
 // NewServer creates a new MCP server instance.
-func NewServer(haClient homeassistant.Client, registry *Registry, port int, logger *logging.Logger) *Server {
+// clientPool is required for per-request token authentication.
+// defaultClient is optional - used when no Authorization header is provided.
+func NewServer(
+	clientPool *homeassistant.ClientPool,
+	defaultClient homeassistant.Client,
+	registry *Registry,
+	port int,
+	logger *logging.Logger,
+) *Server {
 	if logger == nil {
 		logger = logging.New(logging.LevelInfo)
 	}
 	return &Server{
-		haClient: haClient,
-		registry: registry,
-		port:     port,
-		logger:   logger,
+		clientPool:    clientPool,
+		defaultClient: defaultClient,
+		registry:      registry,
+		port:          port,
+		logger:        logger,
 	}
 }
 
@@ -133,7 +144,7 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	// DEBUG: Log method and summary
 	s.logger.Debug("Request", "method", req.Method, "id", formatID(req.ID))
 
-	resp := s.handleRequest(r.Context(), &req)
+	resp := s.handleRequest(r.Context(), &req, r)
 
 	duration := time.Since(startTime)
 	s.logResponse(&req, resp, duration)
@@ -186,7 +197,7 @@ func formatID(id json.RawMessage) string {
 }
 
 // handleRequest routes the request to the appropriate handler.
-func (s *Server) handleRequest(ctx context.Context, req *Request) *Response {
+func (s *Server) handleRequest(ctx context.Context, req *Request, r *http.Request) *Response {
 	switch req.Method {
 	case MethodInitialize:
 		return s.handleInitialize(req)
@@ -197,11 +208,11 @@ func (s *Server) handleRequest(ctx context.Context, req *Request) *Response {
 	case MethodToolsList:
 		return s.handleToolsList(req)
 	case MethodToolsCall:
-		return s.handleToolsCall(ctx, req)
+		return s.handleToolsCall(ctx, req, r)
 	case MethodResourcesList:
 		return s.handleResourcesList(req)
 	case MethodResourcesRead:
-		return s.handleResourcesRead(ctx, req)
+		return s.handleResourcesRead(ctx, req, r)
 	default:
 		s.logger.Warn("Unknown method requested", "method", req.Method)
 		return NewErrorResponse(req.ID, MethodNotFound, fmt.Sprintf("method not found: %s", req.Method), nil)
@@ -286,13 +297,20 @@ func (s *Server) handleToolsList(req *Request) *Response {
 }
 
 // handleToolsCall handles tools/call requests.
-func (s *Server) handleToolsCall(ctx context.Context, req *Request) *Response {
+func (s *Server) handleToolsCall(ctx context.Context, req *Request, r *http.Request) *Response {
 	var params ToolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return NewErrorResponse(req.ID, InvalidParams, "invalid tools/call params", err.Error())
 	}
 
 	s.logger.Info("Tool call", "tool", params.Name)
+
+	// Get HA client for this request
+	client, err := s.getClientForRequest(ctx, r)
+	if err != nil {
+		s.logger.Error("Failed to get HA client", "tool", params.Name, "error", err)
+		return NewErrorResponse(req.ID, Unauthorized, err.Error(), nil)
+	}
 
 	// DEBUG: Log tool arguments summary
 	if s.logger.IsDebugEnabled() {
@@ -302,8 +320,8 @@ func (s *Server) handleToolsCall(ctx context.Context, req *Request) *Response {
 
 	// TRACE: Log full arguments
 	if s.logger.IsTraceEnabled() {
-		argsJSON, err := json.MarshalIndent(params.Arguments, "", "  ")
-		if err == nil {
+		argsJSON, marshalErr := json.MarshalIndent(params.Arguments, "", "  ")
+		if marshalErr == nil {
 			s.logger.Trace("Tool call arguments", "arguments", string(argsJSON))
 		}
 	}
@@ -314,7 +332,7 @@ func (s *Server) handleToolsCall(ctx context.Context, req *Request) *Response {
 		return NewErrorResponse(req.ID, ToolNotFound, fmt.Sprintf("tool not found: %s", params.Name), nil)
 	}
 
-	result, err := handler(ctx, s.haClient, params.Arguments)
+	result, err := handler(ctx, client, params.Arguments)
 	if err != nil {
 		s.logger.Error("Tool execution failed", "tool", params.Name, "error", err)
 		return NewErrorResponse(req.ID, ToolExecutionErr, fmt.Sprintf("tool execution failed: %s", err.Error()), nil)
@@ -352,7 +370,7 @@ func (s *Server) handleResourcesList(req *Request) *Response {
 }
 
 // handleResourcesRead handles resources/read requests.
-func (s *Server) handleResourcesRead(ctx context.Context, req *Request) *Response {
+func (s *Server) handleResourcesRead(ctx context.Context, req *Request, r *http.Request) *Response {
 	var params ResourcesReadParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return NewErrorResponse(req.ID, InvalidParams, "invalid resources/read params", err.Error())
@@ -360,13 +378,20 @@ func (s *Server) handleResourcesRead(ctx context.Context, req *Request) *Respons
 
 	s.logger.Info("Resource read", "uri", params.URI)
 
+	// Get HA client for this request
+	client, err := s.getClientForRequest(ctx, r)
+	if err != nil {
+		s.logger.Error("Failed to get HA client", "uri", params.URI, "error", err)
+		return NewErrorResponse(req.ID, Unauthorized, err.Error(), nil)
+	}
+
 	handler, exists := s.registry.GetResourceHandler(params.URI)
 	if !exists {
 		s.logger.Warn("Resource not found", "uri", params.URI)
 		return NewErrorResponse(req.ID, ResourceNotFound, fmt.Sprintf("resource not found: %s", params.URI), nil)
 	}
 
-	result, err := handler(ctx, s.haClient, params.URI)
+	result, err := handler(ctx, client, params.URI)
 	if err != nil {
 		s.logger.Error("Resource read failed", "uri", params.URI, "error", err)
 		return NewErrorResponse(req.ID, InternalError, fmt.Sprintf("resource read failed: %s", err.Error()), nil)
@@ -410,7 +435,59 @@ func (s *Server) IsInitialized() bool {
 	return s.initialized
 }
 
-// HAClient returns the Home Assistant client for use by handlers.
-func (s *Server) HAClient() homeassistant.Client {
-	return s.haClient
+// extractBearerToken extracts the token from an Authorization: Bearer header.
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return ""
+}
+
+// getClientForRequest returns the appropriate HA client for the request.
+// It uses the token from the Authorization header if present, otherwise falls back to defaultClient.
+func (s *Server) getClientForRequest(ctx context.Context, r *http.Request) (homeassistant.Client, error) {
+	token := extractBearerToken(r)
+
+	if token != "" {
+		// Use token from header
+		client, err := s.clientPool.GetOrCreate(ctx, token)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Home Assistant: %w", err)
+		}
+		return client, nil
+	}
+
+	// Fall back to default client if configured
+	if s.defaultClient != nil {
+		// Check if client needs to wait for reconnection
+		if err := waitForClientConnection(ctx, s.defaultClient); err != nil {
+			return nil, fmt.Errorf("home assistant connection failed: %w", err)
+		}
+		return s.defaultClient, nil
+	}
+
+	return nil, errors.New("authorization header with Bearer token required")
+}
+
+// waitForClientConnection waits for the client to be connected if it supports connection waiting.
+// This is used to handle cases where the client is reconnecting after a disconnect.
+func waitForClientConnection(ctx context.Context, client homeassistant.Client) error {
+	type connectionWaiter interface {
+		IsConnected() bool
+		WaitForConnection(ctx context.Context) error
+	}
+
+	if waiter, ok := client.(connectionWaiter); ok {
+		if !waiter.IsConnected() {
+			return waiter.WaitForConnection(ctx)
+		}
+	}
+	return nil
+}
+
+// DefaultClient returns the default Home Assistant client (from --ha-token).
+// Returns nil if no default client is configured.
+func (s *Server) DefaultClient() homeassistant.Client {
+	return s.defaultClient
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -19,6 +19,15 @@ import (
 	"github.com/zorak1103/ha-mcp/internal/logging"
 )
 
+// newTestServer creates a test server with a default client (for backwards compatibility tests).
+//
+//nolint:unparam // port is always 8080 in tests, which is intentional for test consistency
+func newTestServer(defaultClient homeassistant.Client, registry *Registry, port int, logger *logging.Logger) *Server {
+	// Create a dummy client pool for tests (won't be used when defaultClient is set)
+	pool := homeassistant.NewClientPool("http://localhost:8123", 30*time.Minute)
+	return NewServer(pool, defaultClient, registry, port, logger)
+}
+
 // mockHAClient implements homeassistant.Client for testing.
 type mockHAClient struct{}
 
@@ -178,25 +187,32 @@ func TestNewServer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		haClient homeassistant.Client
-		registry *Registry
-		port     int
-		logger   *logging.Logger
+		name          string
+		defaultClient homeassistant.Client
+		registry      *Registry
+		port          int
+		logger        *logging.Logger
 	}{
 		{
-			name:     "with all parameters",
-			haClient: &mockHAClient{},
-			registry: NewRegistry(),
-			port:     8080,
-			logger:   logging.New(logging.LevelOff),
+			name:          "with all parameters",
+			defaultClient: &mockHAClient{},
+			registry:      NewRegistry(),
+			port:          8080,
+			logger:        logging.New(logging.LevelOff),
 		},
 		{
-			name:     "with nil logger",
-			haClient: &mockHAClient{},
-			registry: NewRegistry(),
-			port:     9090,
-			logger:   nil,
+			name:          "with nil logger",
+			defaultClient: &mockHAClient{},
+			registry:      NewRegistry(),
+			port:          9090,
+			logger:        nil,
+		},
+		{
+			name:          "with nil default client",
+			defaultClient: nil,
+			registry:      NewRegistry(),
+			port:          8080,
+			logger:        logging.New(logging.LevelOff),
 		},
 	}
 
@@ -204,13 +220,15 @@ func TestNewServer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := NewServer(tt.haClient, tt.registry, tt.port, tt.logger)
+			pool := homeassistant.NewClientPool("http://localhost:8123", 30*time.Minute)
+			defer pool.Close()
+			s := NewServer(pool, tt.defaultClient, tt.registry, tt.port, tt.logger)
 
 			if s == nil {
 				t.Fatal("NewServer() returned nil")
 			}
-			if s.haClient != tt.haClient {
-				t.Error("haClient not set correctly")
+			if s.defaultClient != tt.defaultClient {
+				t.Error("defaultClient not set correctly")
 			}
 			if s.registry != tt.registry {
 				t.Error("registry not set correctly")
@@ -228,7 +246,7 @@ func TestNewServer(t *testing.T) {
 func TestServer_HandleHealth(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -260,7 +278,7 @@ func TestServer_HandleHealth(t *testing.T) {
 func TestServer_HandleMCP_InvalidMethod(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	tests := []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch}
 
@@ -294,7 +312,7 @@ func TestServer_HandleMCP_InvalidMethod(t *testing.T) {
 func TestServer_HandleMCP_InvalidJSON(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not valid json"))
 	w := httptest.NewRecorder()
@@ -320,7 +338,7 @@ func TestServer_HandleMCP_InvalidJSON(t *testing.T) {
 func TestServer_HandleMCP_InvalidJSONRPCVersion(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	reqBody := `{"jsonrpc":"1.0","id":1,"method":"ping"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(reqBody))
@@ -347,7 +365,7 @@ func TestServer_HandleMCP_InvalidJSONRPCVersion(t *testing.T) {
 func TestServer_HandleInitialize(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	params := InitializeParams{
 		ProtocolVersion: "2024-11-05",
@@ -403,7 +421,7 @@ func TestServer_HandleInitialize(t *testing.T) {
 func TestServer_HandleInitialize_InvalidParams(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -440,7 +458,7 @@ func TestServer_HandleInitialized(t *testing.T) {
 	t.Run("notification without id", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		reqBody := Request{
 			JSONRPC: JSONRPCVersion,
@@ -470,7 +488,7 @@ func TestServer_HandleInitialized(t *testing.T) {
 	t.Run("request with id", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		reqBody := Request{
 			JSONRPC: JSONRPCVersion,
@@ -506,7 +524,7 @@ func TestServer_HandleInitialized(t *testing.T) {
 func TestServer_HandlePing(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -540,7 +558,7 @@ func TestServer_HandleToolsList(t *testing.T) {
 	registry.RegisterTool(Tool{Name: "tool_a", Description: "Tool A"}, nil)
 	registry.RegisterTool(Tool{Name: "tool_b", Description: "Tool B"}, nil)
 
-	s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -593,7 +611,7 @@ func TestServer_HandleToolsCall(t *testing.T) {
 			},
 		)
 
-		s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 		params := ToolsCallParams{
 			Name:      "test_tool",
@@ -630,7 +648,7 @@ func TestServer_HandleToolsCall(t *testing.T) {
 	t.Run("tool not found", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		params := ToolsCallParams{Name: "nonexistent"}
 		paramsJSON, _ := json.Marshal(params)
@@ -675,7 +693,7 @@ func TestServer_HandleToolsCall(t *testing.T) {
 			},
 		)
 
-		s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 		params := ToolsCallParams{Name: "failing_tool"}
 		paramsJSON, _ := json.Marshal(params)
@@ -712,7 +730,7 @@ func TestServer_HandleToolsCall(t *testing.T) {
 	t.Run("invalid params", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		reqBody := Request{
 			JSONRPC: JSONRPCVersion,
@@ -751,7 +769,7 @@ func TestServer_HandleResourcesList(t *testing.T) {
 	registry.RegisterResource(Resource{URI: "test://a", Name: "Resource A"}, nil)
 	registry.RegisterResource(Resource{URI: "test://b", Name: "Resource B"}, nil)
 
-	s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -804,7 +822,7 @@ func TestServer_HandleResourcesRead(t *testing.T) {
 			},
 		)
 
-		s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 		params := ResourcesReadParams{URI: "test://resource"}
 		paramsJSON, _ := json.Marshal(params)
@@ -838,7 +856,7 @@ func TestServer_HandleResourcesRead(t *testing.T) {
 	t.Run("resource not found", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		params := ResourcesReadParams{URI: "test://nonexistent"}
 		paramsJSON, _ := json.Marshal(params)
@@ -883,7 +901,7 @@ func TestServer_HandleResourcesRead(t *testing.T) {
 			},
 		)
 
-		s := NewServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
 
 		params := ResourcesReadParams{URI: "test://failing"}
 		paramsJSON, _ := json.Marshal(params)
@@ -920,7 +938,7 @@ func TestServer_HandleResourcesRead(t *testing.T) {
 	t.Run("invalid params", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		reqBody := Request{
 			JSONRPC: JSONRPCVersion,
@@ -955,7 +973,7 @@ func TestServer_HandleResourcesRead(t *testing.T) {
 func TestServer_UnknownMethod(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -988,7 +1006,7 @@ func TestServer_UnknownMethod(t *testing.T) {
 func TestServer_IsInitialized(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	if s.IsInitialized() {
 		t.Error("IsInitialized() = true, want false for new server")
@@ -1010,14 +1028,20 @@ func TestServer_IsInitialized(t *testing.T) {
 	}
 }
 
-func TestServer_HAClient(t *testing.T) {
+func TestServer_DefaultClient(t *testing.T) {
 	t.Parallel()
 
 	client := &mockHAClient{}
-	s := NewServer(client, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(client, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
-	if s.HAClient() != client {
-		t.Error("HAClient() did not return the expected client")
+	if s.DefaultClient() != client {
+		t.Error("DefaultClient() did not return the expected client")
+	}
+
+	// Test with nil default client
+	sNoDefault := newTestServer(nil, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	if sNoDefault.DefaultClient() != nil {
+		t.Error("DefaultClient() should return nil when no default client is configured")
 	}
 }
 
@@ -1027,7 +1051,7 @@ func TestServer_Shutdown(t *testing.T) {
 	t.Run("shutdown nil server", func(t *testing.T) {
 		t.Parallel()
 
-		s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+		s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 		// httpServer is nil before Start() is called
 		err := s.Shutdown(context.Background())
@@ -1145,7 +1169,7 @@ func TestServer_Constants(t *testing.T) {
 func TestServer_HandleInitialize_NilParams(t *testing.T) {
 	t.Parallel()
 
-	s := NewServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
+	s := newTestServer(&mockHAClient{}, NewRegistry(), 8080, logging.New(logging.LevelOff))
 
 	reqBody := Request{
 		JSONRPC: JSONRPCVersion,
@@ -1171,5 +1195,209 @@ func TestServer_HandleInitialize_NilParams(t *testing.T) {
 	// Should succeed with nil params (uses default values)
 	if jsonResp.Error != nil {
 		t.Fatalf("Unexpected error: %+v", jsonResp.Error)
+	}
+}
+
+func TestExtractBearerToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		authHdr string
+		want    string
+	}{
+		{
+			name:    "valid bearer token",
+			authHdr: "Bearer my-secret-token",
+			want:    "my-secret-token",
+		},
+		{
+			name:    "empty header",
+			authHdr: "",
+			want:    "",
+		},
+		{
+			name:    "no bearer prefix",
+			authHdr: "my-token",
+			want:    "",
+		},
+		{
+			name:    "basic auth header",
+			authHdr: "Basic dXNlcjpwYXNz",
+			want:    "",
+		},
+		{
+			name:    "lowercase bearer",
+			authHdr: "bearer my-token",
+			want:    "",
+		},
+		{
+			name:    "bearer with space only",
+			authHdr: "Bearer ",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tt.authHdr != "" {
+				req.Header.Set("Authorization", tt.authHdr)
+			}
+
+			got := extractBearerToken(req)
+			if got != tt.want {
+				t.Errorf("extractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServer_ToolsCall_NoAuth(t *testing.T) {
+	t.Parallel()
+
+	// Server with no default client - requires auth header
+	pool := homeassistant.NewClientPool("http://localhost:8123", 30*time.Minute)
+	defer pool.Close()
+
+	registry := NewRegistry()
+	registry.RegisterTool(
+		Tool{Name: "test_tool"},
+		func(_ context.Context, _ homeassistant.Client, _ map[string]any) (*ToolsCallResult, error) {
+			return &ToolsCallResult{Content: []ContentBlock{NewTextContent("success")}}, nil
+		},
+	)
+
+	s := NewServer(pool, nil, registry, 8080, logging.New(logging.LevelOff))
+
+	params := ToolsCallParams{Name: "test_tool"}
+	paramsJSON, _ := json.Marshal(params)
+
+	reqBody := Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodToolsCall,
+		Params:  paramsJSON,
+	}
+	reqBodyJSON, _ := json.Marshal(reqBody)
+
+	// Request without Authorization header
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBodyJSON))
+	w := httptest.NewRecorder()
+
+	s.handleMCP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	var jsonResp Response
+	if err := json.NewDecoder(resp.Body).Decode(&jsonResp); err != nil {
+		t.Fatalf("json.Decode() error = %v", err)
+	}
+
+	if jsonResp.Error == nil {
+		t.Fatal("Expected Unauthorized error")
+	}
+	if jsonResp.Error.Code != Unauthorized {
+		t.Errorf("Error.Code = %d, want %d (Unauthorized)", jsonResp.Error.Code, Unauthorized)
+	}
+	if !strings.Contains(jsonResp.Error.Message, "authorization header") {
+		t.Errorf("Error.Message = %q, expected to mention authorization header", jsonResp.Error.Message)
+	}
+}
+
+func TestServer_ToolsCall_WithDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	// Server with default client - no auth header required
+	registry := NewRegistry()
+	registry.RegisterTool(
+		Tool{Name: "test_tool"},
+		func(_ context.Context, _ homeassistant.Client, _ map[string]any) (*ToolsCallResult, error) {
+			return &ToolsCallResult{Content: []ContentBlock{NewTextContent("success")}}, nil
+		},
+	)
+
+	s := newTestServer(&mockHAClient{}, registry, 8080, logging.New(logging.LevelOff))
+
+	params := ToolsCallParams{Name: "test_tool"}
+	paramsJSON, _ := json.Marshal(params)
+
+	reqBody := Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodToolsCall,
+		Params:  paramsJSON,
+	}
+	reqBodyJSON, _ := json.Marshal(reqBody)
+
+	// Request without Authorization header but with default client configured
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBodyJSON))
+	w := httptest.NewRecorder()
+
+	s.handleMCP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	var jsonResp Response
+	if err := json.NewDecoder(resp.Body).Decode(&jsonResp); err != nil {
+		t.Fatalf("json.Decode() error = %v", err)
+	}
+
+	if jsonResp.Error != nil {
+		t.Fatalf("Unexpected error: %+v", jsonResp.Error)
+	}
+}
+
+func TestServer_ResourcesRead_NoAuth(t *testing.T) {
+	t.Parallel()
+
+	// Server with no default client - requires auth header
+	pool := homeassistant.NewClientPool("http://localhost:8123", 30*time.Minute)
+	defer pool.Close()
+
+	registry := NewRegistry()
+	registry.RegisterResource(
+		Resource{URI: "test://resource", Name: "Test"},
+		func(_ context.Context, _ homeassistant.Client, uri string) (*ResourcesReadResult, error) {
+			return &ResourcesReadResult{Contents: []ResourceContent{{URI: uri, Text: "content"}}}, nil
+		},
+	)
+
+	s := NewServer(pool, nil, registry, 8080, logging.New(logging.LevelOff))
+
+	params := ResourcesReadParams{URI: "test://resource"}
+	paramsJSON, _ := json.Marshal(params)
+
+	reqBody := Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodResourcesRead,
+		Params:  paramsJSON,
+	}
+	reqBodyJSON, _ := json.Marshal(reqBody)
+
+	// Request without Authorization header
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBodyJSON))
+	w := httptest.NewRecorder()
+
+	s.handleMCP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	var jsonResp Response
+	if err := json.NewDecoder(resp.Body).Decode(&jsonResp); err != nil {
+		t.Fatalf("json.Decode() error = %v", err)
+	}
+
+	if jsonResp.Error == nil {
+		t.Fatal("Expected Unauthorized error")
+	}
+	if jsonResp.Error.Code != Unauthorized {
+		t.Errorf("Error.Code = %d, want %d (Unauthorized)", jsonResp.Error.Code, Unauthorized)
 	}
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -48,6 +48,7 @@ const (
 	ResourceNotFound ErrorCode = -32001
 	ToolNotFound     ErrorCode = -32002
 	ToolExecutionErr ErrorCode = -32003
+	Unauthorized     ErrorCode = -32004 // Authentication required
 )
 
 // MCP Protocol Methods.


### PR DESCRIPTION
- Updated configuration to make Home Assistant token optional, allowing clients to send tokens via Authorization header.
- Introduced ClientPool to manage Home Assistant clients, enabling efficient token handling and idle connection cleanup.
- Modified server to extract bearer tokens from requests and use them for client authentication.
- Enhanced tests to cover new authentication flow and ensure proper handling of missing tokens.
- Added methods to check client connection status and wait for reconnections.
- Updated error handling to return unauthorized responses when no valid token is provided.