### PR TITLE
fix(dashboard): detect and correct view reorder after patch save (#66)

### DIFF
--- a/internal/handlers/integration/dashboards_integration_test.go
+++ b/internal/handlers/integration/dashboards_integration_test.go
@@ -431,3 +431,95 @@ func (s *DashboardIntegrationTestSuite) TestDashboardCreatedWithSectionLayout() 
 	// Cleanup
 	_ = s.Client().DeleteDashboard(s.Context(), dashboardID)
 }
+
+// TestDashboardPatchPreservesViewOrder is a regression test for issue #66:
+// replace /views/N must not reorder sibling views when HA persists the config.
+func (s *DashboardIntegrationTestSuite) TestDashboardPatchPreservesViewOrder() {
+	urlPath := generateDashboardURLPath("dash-patch-order")
+
+	var dashboardID string
+
+	s.RegisterCleanup(func() {
+		if dashboardID != "" {
+			_ = s.Client().DeleteDashboard(s.Context(), dashboardID)
+		}
+	})
+
+	requireAdmin := false
+	showInSidebar := false
+
+	// Create a test dashboard
+	cfg := homeassistant.DashboardConfig{
+		URLPath:       urlPath,
+		Title:         "Patch Order Test",
+		Mode:          "storage",
+		RequireAdmin:  &requireAdmin,
+		ShowInSidebar: &showInSidebar,
+	}
+
+	created, err := s.Client().CreateDashboard(s.Context(), cfg)
+	s.Require().NoError(err, "Failed to create test dashboard")
+	s.Require().NotNil(created)
+
+	dashboardID = created.ID
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Save a 4-view baseline (matches the real-world reproducer from issue #66)
+	baseline := map[string]any{
+		"views": []any{
+			map[string]any{"title": "Übersicht", "path": "overview"},
+			map[string]any{"title": "Twingo", "path": "twingo"},
+			map[string]any{"title": "IONIQ 6", "path": "ioniq"},
+			map[string]any{"title": "Wallbox", "path": "wallbox"},
+		},
+	}
+
+	err = s.Client().SaveLovelaceConfig(s.Context(), urlPath, baseline)
+	s.Require().NoError(err, "Failed to save baseline config")
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify baseline was saved correctly
+	before, err := s.Client().GetLovelaceConfig(s.Context(), urlPath)
+	s.Require().NoError(err, "Failed to retrieve baseline config")
+
+	beforeViews, ok := before["views"].([]any)
+	s.Require().True(ok, "Baseline views should be a slice")
+	s.Require().Len(beforeViews, 4, "Baseline should have 4 views")
+	s.Equal("Übersicht", beforeViews[0].(map[string]any)["title"], "views[0] before patch")
+	s.Equal("Twingo", beforeViews[1].(map[string]any)["title"], "views[1] before patch")
+	s.Equal("IONIQ 6", beforeViews[2].(map[string]any)["title"], "views[2] before patch")
+	s.Equal("Wallbox", beforeViews[3].(map[string]any)["title"], "views[3] before patch")
+
+	// Apply a replace on views[2] — the operation from the issue report
+	patched := map[string]any{
+		"views": []any{
+			beforeViews[0],
+			beforeViews[1],
+			map[string]any{"title": "IONIQ 6 Pro", "path": "ioniq"},
+			beforeViews[3],
+		},
+	}
+
+	err = s.Client().SaveLovelaceConfig(s.Context(), urlPath, patched)
+	s.Require().NoError(err, "Failed to save patched config")
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Read back and verify view order is preserved
+	after, err := s.Client().GetLovelaceConfig(s.Context(), urlPath)
+	s.Require().NoError(err, "Failed to retrieve patched config")
+
+	afterViews, ok := after["views"].([]any)
+	s.Require().True(ok, "Patched views should be a slice")
+	s.Require().Len(afterViews, 4, "Patched config should still have 4 views")
+
+	wantTitles := []string{"Übersicht", "Twingo", "IONIQ 6 Pro", "Wallbox"}
+	for i, v := range afterViews {
+		vm, ok := v.(map[string]any)
+		s.Require().True(ok, "views[%d] should be a map", i)
+		s.Equal(wantTitles[i], vm["title"],
+			"views[%d].title after patch (sibling order must not change)", i)
+	}
+}

--- a/internal/handlers/lovelace.go
+++ b/internal/handlers/lovelace.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/jsonpatch"
 	"github.com/zorak1103/ha-mcp/internal/mcp"
 )
 
@@ -346,12 +347,147 @@ func (h *DashboardHandlers) handlePatch(ctx context.Context, client homeassistan
 		return errorResult(fmt.Sprintf("error saving patched dashboard: %v", err)), nil
 	}
 
+	corrected, warning := h.correctViewOrder(ctx, client, urlPath, patchedMap)
+
 	target := "default dashboard"
 	if urlPath != "" {
 		target = fmt.Sprintf("dashboard '%s'", urlPath)
 	}
 
-	return successResult(fmt.Sprintf("Dashboard patched successfully for %s (%d operations applied)", target, len(ops))), nil
+	msg := fmt.Sprintf("Dashboard patched successfully for %s (%d operations applied)", target, len(ops))
+	if corrected {
+		msg += "\nNote: Home Assistant reordered views after save; order has been automatically restored."
+	}
+	if warning != "" {
+		msg += "\n" + warning
+	}
+	return successResult(msg), nil
+}
+
+// correctViewOrder reads back the saved config from HA and, if the views array
+// is in a different order than intended, applies move ops to restore it.
+// Returns (corrected bool, warningMsg string).
+func (h *DashboardHandlers) correctViewOrder(
+	ctx context.Context,
+	client homeassistant.Client,
+	urlPath string,
+	intended map[string]any,
+) (bool, string) {
+	intendedViews, ok := intended["views"].([]any)
+	if !ok || len(intendedViews) == 0 {
+		return false, ""
+	}
+
+	actual, err := client.GetLovelaceConfig(ctx, urlPath)
+	if err != nil {
+		return false, fmt.Sprintf("(could not verify view order after save: %v)", err)
+	}
+
+	actualViews, ok := actual["views"].([]any)
+	if !ok || len(actualViews) != len(intendedViews) {
+		return false, ""
+	}
+
+	if viewsInOrder(intendedViews, actualViews) {
+		return false, ""
+	}
+
+	moveOps := buildViewMoveOps(intendedViews, actualViews)
+	if len(moveOps) == 0 {
+		return false, ""
+	}
+
+	restored, applyErr := jsonpatch.Apply(actual, moveOps)
+	if applyErr != nil {
+		return false, fmt.Sprintf("(could not build view-order correction: %v)", applyErr)
+	}
+
+	restoredMap, ok := restored.(map[string]any)
+	if !ok {
+		return false, ""
+	}
+
+	if saveErr := client.SaveLovelaceConfig(ctx, urlPath, restoredMap); saveErr != nil {
+		return false, fmt.Sprintf("(view-order correction save failed: %v)", saveErr)
+	}
+
+	return true, ""
+}
+
+// buildViewMoveOps produces RFC 6902 move ops that restore actualViews to
+// the order specified by intendedViews. Works left-to-right using a selection-sort
+// approach, simulating each move on a working copy to keep indices accurate.
+func buildViewMoveOps(intendedViews, actualViews []any) []jsonpatch.Operation {
+	working := make([]any, len(actualViews))
+	copy(working, actualViews)
+
+	var ops []jsonpatch.Operation
+	for i, want := range intendedViews {
+		cur := findViewIndex(working, want, i)
+		if cur == i || cur < 0 {
+			continue
+		}
+		ops = append(ops, jsonpatch.Operation{
+			Op:   "move",
+			From: fmt.Sprintf("/views/%d", cur),
+			Path: fmt.Sprintf("/views/%d", i),
+		})
+		// Simulate the move so subsequent index lookups stay correct.
+		elem := working[cur]
+		working = append(working[:cur], working[cur+1:]...)
+		newSlice := make([]any, len(working)+1)
+		copy(newSlice[:i], working[:i])
+		copy(newSlice[i+1:], working[i:])
+		newSlice[i] = elem
+		working = newSlice
+	}
+	return ops
+}
+
+// viewsInOrder returns true when actual contains the same view identities in
+// the same positions as intended.
+func viewsInOrder(intended, actual []any) bool {
+	for i, want := range intended {
+		if !viewIdentityMatch(want, actual[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// findViewIndex returns the index in working where the view matching want is found,
+// starting the search from startFrom. Returns -1 if not found.
+func findViewIndex(working []any, want any, startFrom int) int {
+	// Prefer exact identity match; fall back to path-or-title match.
+	for i := startFrom; i < len(working); i++ {
+		if viewIdentityMatch(want, working[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// viewIdentityMatch returns true when two view objects refer to the same view.
+// Identity is determined by "path" field first (most stable), then "title".
+// If neither is present, falls back to deep JSON equality.
+func viewIdentityMatch(a, b any) bool {
+	am, aOk := a.(map[string]any)
+	bm, bOk := b.(map[string]any)
+	if !aOk || !bOk {
+		return jsonValEqual(a, b)
+	}
+
+	if ap, ok := am["path"].(string); ok && ap != "" {
+		bp, _ := bm["path"].(string)
+		return ap == bp
+	}
+
+	if at, ok := am["title"].(string); ok && at != "" {
+		bt, _ := bm["title"].(string)
+		return at == bt
+	}
+
+	return jsonValEqual(a, b)
 }
 
 // =============================================================================

--- a/internal/handlers/lovelace_test.go
+++ b/internal/handlers/lovelace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/jsonpatch"
 	"github.com/zorak1103/ha-mcp/internal/mcp"
 )
 
@@ -804,6 +805,173 @@ func TestHandleManageDashboard_Patch_ViewOrderPreserved(t *testing.T) {
 		if vm["title"] != want[i] {
 			t.Errorf("views[%d].title = %v, want %q (sibling order changed)", i, vm["title"], want[i])
 		}
+	}
+}
+
+// TestBuildViewMoveOps verifies that the move-op generator produces ops that
+// correctly restore an intended view order from a scrambled actual order.
+func TestBuildViewMoveOps(t *testing.T) {
+	t.Parallel()
+
+	view := func(path string) any {
+		return map[string]any{"title": path, "path": path}
+	}
+
+	tests := []struct {
+		name     string
+		intended []any
+		actual   []any
+		// wantOrder is the final order after applying the generated ops via jsonpatch.Apply.
+		wantOrder []string
+	}{
+		{
+			name:      "already in order - no ops needed",
+			intended:  []any{view("a"), view("b"), view("c")},
+			actual:    []any{view("a"), view("b"), view("c")},
+			wantOrder: []string{"a", "b", "c"},
+		},
+		{
+			name:      "two adjacent views swapped",
+			intended:  []any{view("a"), view("b"), view("c"), view("d")},
+			actual:    []any{view("b"), view("a"), view("c"), view("d")},
+			wantOrder: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:      "first view moved to last",
+			intended:  []any{view("a"), view("b"), view("c")},
+			actual:    []any{view("b"), view("c"), view("a")},
+			wantOrder: []string{"a", "b", "c"},
+		},
+		{
+			name:      "full reverse",
+			intended:  []any{view("a"), view("b"), view("c"), view("d")},
+			actual:    []any{view("d"), view("c"), view("b"), view("a")},
+			wantOrder: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ops := buildViewMoveOps(tc.intended, tc.actual)
+
+			// Apply the generated move ops to the actual doc.
+			doc := map[string]any{"views": tc.actual}
+			result, err := jsonpatch.Apply(doc, ops)
+			if err != nil {
+				// No ops needed → Apply should be a no-op on the unchanged doc.
+				if len(ops) == 0 {
+					result = doc
+				} else {
+					t.Fatalf("Apply(moveOps) error: %v", err)
+				}
+			}
+
+			views := result.(map[string]any)["views"].([]any)
+			if len(views) != len(tc.wantOrder) {
+				t.Fatalf("len(views) = %d, want %d", len(views), len(tc.wantOrder))
+			}
+			for i, v := range views {
+				got := v.(map[string]any)["path"]
+				if got != tc.wantOrder[i] {
+					t.Errorf("views[%d].path = %v, want %q", i, got, tc.wantOrder[i])
+				}
+			}
+		})
+	}
+}
+
+// TestHandleManageDashboard_Patch_HAReordersCorrected verifies that when HA
+// returns a reordered views array after save, the handler detects and corrects it.
+func TestHandleManageDashboard_Patch_HAReordersCorrected(t *testing.T) {
+	t.Parallel()
+
+	// Initial config with 4 views in intended order.
+	initial := map[string]any{
+		"title": "Home",
+		"views": []any{
+			map[string]any{"title": "A", "path": "a"},
+			map[string]any{"title": "B", "path": "b"},
+			map[string]any{"title": "C", "path": "c"},
+			map[string]any{"title": "D", "path": "d"},
+		},
+	}
+
+	// Simulated HA response after save: views[0] and views[1] swapped (the bug).
+	haReordered := map[string]any{
+		"title": "Home",
+		"views": []any{
+			map[string]any{"title": "B", "path": "b"},
+			map[string]any{"title": "A", "path": "a"},
+			map[string]any{"title": "C updated", "path": "c"},
+			map[string]any{"title": "D", "path": "d"},
+		},
+	}
+
+	h := NewDashboardHandlers()
+
+	getCallCount := 0
+	var savedConfigs []map[string]any
+	m := &UniversalMockClient{
+		GetLovelaceConfigFn: func(_ context.Context, _ string) (map[string]any, error) {
+			getCallCount++
+			if getCallCount == 1 {
+				return deepCopyMap(initial), nil
+			}
+			// Second call (post-save read-back) returns HA's reordered version.
+			return deepCopyMap(haReordered), nil
+		},
+		SaveLovelaceConfigFn: func(_ context.Context, _ string, cfg map[string]any) error {
+			savedConfigs = append(savedConfigs, cfg)
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	result, err := h.handleManageDashboard(ctx, m, map[string]any{
+		"action": "patch",
+		"operations": []any{
+			map[string]any{
+				"op":    "replace",
+				"path":  "/views/2/title",
+				"value": "C updated",
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("handler returned nil result")
+	}
+
+	// Should have called SaveLovelaceConfig twice: once for the patch, once for the correction.
+	if len(savedConfigs) != 2 {
+		t.Fatalf("SaveLovelaceConfig called %d times, want 2 (patch + correction)", len(savedConfigs))
+	}
+
+	// The correction save (second call) must have the intended view order.
+	corrected := savedConfigs[1]["views"].([]any)
+	wantPaths := []string{"a", "b", "c", "d"}
+	if len(corrected) != len(wantPaths) {
+		t.Fatalf("corrected views len = %d, want %d", len(corrected), len(wantPaths))
+	}
+	for i, v := range corrected {
+		vm, _ := v.(map[string]any)
+		if vm["path"] != wantPaths[i] {
+			t.Errorf("corrected views[%d].path = %v, want %q", i, vm["path"], wantPaths[i])
+		}
+	}
+
+	// Success message must mention the correction.
+	var msgText string
+	for _, cb := range result.Content {
+		msgText += cb.Text
+	}
+	if !strings.Contains(msgText, "reordered") {
+		t.Errorf("success message should mention the reorder correction, got: %q", msgText)
 	}
 }
 

--- a/internal/handlers/lovelace_test.go
+++ b/internal/handlers/lovelace_test.go
@@ -737,6 +737,76 @@ func TestHandleManageDashboard_Patch(t *testing.T) {
 	runHandlerTestCases(t, tests, h.handleManageDashboard)
 }
 
+// TestHandleManageDashboard_Patch_ViewOrderPreserved is a dedicated regression
+// test for issue #66: replace /views/N must not reorder sibling views.
+func TestHandleManageDashboard_Patch_ViewOrderPreserved(t *testing.T) {
+	t.Parallel()
+
+	fourViewConfig := map[string]any{
+		"title": "Home",
+		"views": []any{
+			map[string]any{"title": "Übersicht", "path": "overview"},
+			map[string]any{"title": "Twingo", "path": "twingo"},
+			map[string]any{"title": "IONIQ 6", "path": "ioniq"},
+			map[string]any{"title": "Wallbox", "path": "wallbox"},
+		},
+	}
+
+	h := NewDashboardHandlers()
+
+	var savedConfig map[string]any
+	m := &UniversalMockClient{
+		GetLovelaceConfigFn: func(context.Context, string) (map[string]any, error) {
+			return deepCopyMap(fourViewConfig), nil
+		},
+		SaveLovelaceConfigFn: func(_ context.Context, _ string, cfg map[string]any) error {
+			savedConfig = cfg
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	result, err := h.handleManageDashboard(ctx, m, map[string]any{
+		"action": "patch",
+		"operations": []any{
+			map[string]any{
+				"op":    "replace",
+				"path":  "/views/2",
+				"value": map[string]any{"title": "IONIQ 6 Pro", "path": "ioniq"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("handler returned nil result")
+	}
+
+	if savedConfig == nil {
+		t.Fatal("SaveLovelaceConfig was not called")
+	}
+
+	views, ok := savedConfig["views"].([]any)
+	if !ok {
+		t.Fatalf("saved config 'views' is not []any, got %T", savedConfig["views"])
+	}
+
+	want := []string{"Übersicht", "Twingo", "IONIQ 6 Pro", "Wallbox"}
+	if len(views) != len(want) {
+		t.Fatalf("len(views) = %d, want %d", len(views), len(want))
+	}
+	for i, v := range views {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			t.Fatalf("views[%d] is not a map, got %T", i, v)
+		}
+		if vm["title"] != want[i] {
+			t.Errorf("views[%d].title = %v, want %q (sibling order changed)", i, vm["title"], want[i])
+		}
+	}
+}
+
 func TestHandleManageDashboard_SemanticPatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/jsonpatch/apply_test.go
+++ b/internal/jsonpatch/apply_test.go
@@ -246,6 +246,88 @@ func TestApply_Replace(t *testing.T) {
 			t.Fatal("expected error for missing key in replace")
 		}
 	})
+
+	// Regression tests for issue #66: replace on /array/N must not reorder siblings.
+
+	t.Run("replace preserves sibling order - whole element", func(t *testing.T) {
+		t.Parallel()
+
+		result := applyJSON(t,
+			`{"views":[
+				{"title":"Übersicht","path":"overview"},
+				{"title":"Twingo","path":"twingo"},
+				{"title":"IONIQ 6","path":"ioniq"},
+				{"title":"Wallbox","path":"wallbox"}
+			]}`,
+			[]Operation{
+				{Op: "replace", Path: "/views/2", Value: map[string]any{
+					"title": "IONIQ 6 updated", "path": "ioniq",
+				}},
+			})
+
+		views := result.(map[string]any)["views"].([]any)
+		want := []string{"Übersicht", "Twingo", "IONIQ 6 updated", "Wallbox"}
+		if len(views) != len(want) {
+			t.Fatalf("len(views) = %d, want %d", len(views), len(want))
+		}
+		for i, v := range views {
+			got := v.(map[string]any)["title"]
+			if got != want[i] {
+				t.Errorf("views[%d].title = %v, want %q", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("replace preserves sibling order - nested field", func(t *testing.T) {
+		t.Parallel()
+
+		result := applyJSON(t,
+			`{"views":[
+				{"title":"A","path":"a"},
+				{"title":"B","path":"b"},
+				{"title":"C","path":"c"}
+			]}`,
+			[]Operation{
+				{Op: "replace", Path: "/views/2/title", Value: "C updated"},
+			})
+
+		views := result.(map[string]any)["views"].([]any)
+		want := []string{"A", "B", "C updated"}
+		if len(views) != len(want) {
+			t.Fatalf("len(views) = %d, want %d", len(views), len(want))
+		}
+		for i, v := range views {
+			got := v.(map[string]any)["title"]
+			if got != want[i] {
+				t.Errorf("views[%d].title = %v, want %q", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("replace preserves sibling order - 10 elements", func(t *testing.T) {
+		t.Parallel()
+
+		const n = 10
+		// Build a 10-element array as JSON
+		raw := `{"items":[0,1,2,3,4,5,6,7,8,9]}`
+		result := applyJSON(t, raw, []Operation{
+			{Op: "replace", Path: "/items/5", Value: float64(99)},
+		})
+
+		items := result.(map[string]any)["items"].([]any)
+		if len(items) != n {
+			t.Fatalf("len(items) = %d, want %d", len(items), n)
+		}
+		for i, v := range items {
+			want := float64(i)
+			if i == 5 {
+				want = 99
+			}
+			if v != want {
+				t.Errorf("items[%d] = %v, want %v", i, v, want)
+			}
+		}
+	})
 }
 
 func TestApply_Move(t *testing.T) {


### PR DESCRIPTION
## Summary

- After `manage_dashboard(action=patch)` saves to HA, the handler now reads back what HA actually persisted and compares the `views` array order against the intended patched order
- If HA reordered the views (observed on sections-mode storage dashboards), a minimum set of RFC 6902 `move` ops is computed and a corrective re-save is performed automatically
- A note is appended to the success message when a correction was applied
- The RFC 6902 engine and handler pipeline were confirmed correct (no reorder site found in our code) — the bug is HA-side on `lovelace/config/save`

## Why

Issue #66: `replace /views/N` on a dashboard with multiple views caused HA to return a reordered `views` array. In the reporter's case, views at indices 0 and 1 swapped (`[Übersicht, Twingo, …]` → `[Twingo, Übersicht, …]`).

## Implementation

New helpers in `internal/handlers/lovelace.go`:
- `correctViewOrder`: post-save GetLovelaceConfig + detect mismatch → re-save
- `buildViewMoveOps`: left-to-right selection-sort on a working copy → minimal `move` ops
- `viewsInOrder` / `findViewIndex` / `viewIdentityMatch`: identity matching by `path` > `title` > JSON equality

## Test plan

- [x] `TestApply_Replace_PreservesSiblingOrder` (3 subtests) — closes test-coverage gap in jsonpatch engine (whole-element, nested-field, 10-element array)
- [x] `TestHandleManageDashboard_Patch_ViewOrderPreserved` — handler saves views in correct order (no reorder simulation)
- [x] `TestBuildViewMoveOps` — table-driven: identity/adjacent-swap/first-to-last/full-reverse all produce correct ops
- [x] `TestHandleManageDashboard_Patch_HAReordersCorrected` — mocks the 2-call GetLovelaceConfig sequence (fetch + scrambled read-back), verifies second SaveLovelaceConfig restores order and success message mentions correction
- [x] `TestDashboardPatchPreservesViewOrder` (integration, `//go:build integration`) — real HA round-trip; auto-skipped without env vars, will run in CI against actual instance to confirm HA-side behaviour

All unit tests pass, `golangci-lint run --timeout=5m ./...` reports 0 issues.

Closes #66