### PR TITLE
fix(traces): read runtime state via GetState and filter list by entity_id

### DIFF
--- a/internal/handlers/traces.go
+++ b/internal/handlers/traces.go
@@ -53,7 +53,7 @@ func RegisterTraceTools(registry *mcp.Registry) {
 				},
 				"entity_id": {
 					Type:        "string",
-					Description: "Entity ID (required for 'get' action, e.g., 'automation.morning_routine').",
+					Description: "Entity ID for 'get' action (required) or 'list' action (optional, auto-derives domain and filters traces by item, e.g., 'automation.morning_routine').",
 				},
 				"automation_id": {
 					Type:        "string",
@@ -106,15 +106,43 @@ func (h *TraceHandlers) HandleManageTrace(ctx context.Context, client homeassist
 	}
 }
 
+// resolveTraceListParams derives domain and item_id from entity_id (when provided),
+// validates the prefix, and checks for conflicts with an explicit domain parameter.
+func resolveTraceListParams(entityID, domain string) (resolvedDomain, itemID, errMsg string) {
+	if entityID == "" {
+		return domain, "", ""
+	}
+	dotIdx := strings.Index(entityID, ".")
+	if dotIdx <= 0 {
+		return "", "", fmt.Sprintf("entity_id %q is invalid for list action: must be 'automation.<id>' or 'script.<id>'", entityID)
+	}
+	derived := entityID[:dotIdx]
+	if derived != traceDomainAutomation && derived != traceDomainScript {
+		return "", "", fmt.Sprintf("entity_id prefix %q is not supported for trace list; use 'automation' or 'script'", derived)
+	}
+	if domain != "" && domain != derived {
+		return "", "", fmt.Sprintf("entity_id prefix %q conflicts with explicit domain %q", derived, domain)
+	}
+	return derived, entityID, ""
+}
+
 // handleListTraces lists all traces for a domain.
 func (h *TraceHandlers) handleListTraces(ctx context.Context, client homeassistant.Client, args map[string]any, format string) (*mcp.ToolsCallResult, error) {
-	// Extract domain (optional for list)
 	domain, _ := args["domain"].(string)
+	entityID, _ := args["entity_id"].(string)
+
+	domain, itemID, errMsg := resolveTraceListParams(entityID, domain)
+	if errMsg != "" {
+		return errorResult(errMsg), nil
+	}
 
 	// Build command data
 	data := make(map[string]any)
 	if domain != "" {
 		data["domain"] = domain
+	}
+	if itemID != "" {
+		data["item_id"] = itemID
 	}
 
 	// Call trace/list WebSocket command

--- a/internal/handlers/traces_debug.go
+++ b/internal/handlers/traces_debug.go
@@ -127,9 +127,16 @@ func fetchDebugAutomationConfig(ctx context.Context, client homeassistant.Client
 		return nil, nil, fmt.Errorf("automation not found: %w", err)
 	}
 
+	// The HA config endpoint does not return runtime state; fetch it separately.
+	// Best-effort: leave State empty on error rather than failing the whole report.
+	runtimeState := auto.State
+	if entity, stateErr := client.GetState(ctx, entityID); stateErr == nil {
+		runtimeState = entity.State
+	}
+
 	cfg := &AutomationDebugConfig{
 		EntityID:      entityID,
-		State:         auto.State,
+		State:         runtimeState,
 		LastTriggered: auto.LastTriggered,
 	}
 

--- a/internal/handlers/traces_debug_test.go
+++ b/internal/handlers/traces_debug_test.go
@@ -408,6 +408,90 @@ func TestExtractTriggerEntityIDs(t *testing.T) {
 	}
 }
 
+// TestHandleDebugTrace_StateFromGetState verifies that the automation runtime state
+// is read via GetState (not from GetAutomation, which only returns config).
+// Regression test for issue #74: debug report shows empty State field.
+func TestHandleDebugTrace_StateFromGetState(t *testing.T) {
+	t.Parallel()
+
+	handler := NewTraceHandlers()
+	client := &UniversalMockClient{
+		// GetAutomation returns config only — State is empty, as in the real HA API.
+		GetAutomationFn: func(_ context.Context, _ string) (*homeassistant.Automation, error) {
+			auto := mockAutomationForDebug()
+			auto.State = "" // real HA config endpoint does not populate State
+			return auto, nil
+		},
+		// GetState returns the runtime state — this is the authoritative source.
+		GetStateFn: func(_ context.Context, entityID string) (*homeassistant.Entity, error) {
+			return &homeassistant.Entity{
+				EntityID: entityID,
+				State:    "on",
+			}, nil
+		},
+		SendHACSCommandFn: func(_ context.Context, _ string, _ map[string]any) (any, error) {
+			return []any{}, nil
+		},
+		GetLogbookFn: func(_ context.Context, _, _, _ string) ([]homeassistant.LogbookEntry, error) {
+			return []homeassistant.LogbookEntry{}, nil
+		},
+	}
+
+	result, err := handler.HandleManageTrace(context.Background(), client, map[string]any{
+		"action":        "debug",
+		"automation_id": "automation.morning_routine",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", result.Content[0].Text)
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, "State: on") {
+		t.Errorf("expected 'State: on' in output (state must come from GetState, not GetAutomation config)\nfull output:\n%s", text)
+	}
+}
+
+// TestHandleDebugTrace_StateGetStateFails verifies that a GetState failure is handled
+// gracefully: State may appear empty but no error is returned (best-effort).
+func TestHandleDebugTrace_StateGetStateFails(t *testing.T) {
+	t.Parallel()
+
+	handler := NewTraceHandlers()
+	client := &UniversalMockClient{
+		GetAutomationFn: func(_ context.Context, _ string) (*homeassistant.Automation, error) {
+			auto := mockAutomationForDebug()
+			auto.State = ""
+			return auto, nil
+		},
+		GetStateFn: func(_ context.Context, _ string) (*homeassistant.Entity, error) {
+			return nil, fmt.Errorf("entity not found")
+		},
+		SendHACSCommandFn: func(_ context.Context, _ string, _ map[string]any) (any, error) {
+			return []any{}, nil
+		},
+		GetLogbookFn: func(_ context.Context, _, _, _ string) ([]homeassistant.LogbookEntry, error) {
+			return []homeassistant.LogbookEntry{}, nil
+		},
+	}
+
+	result, err := handler.HandleManageTrace(context.Background(), client, map[string]any{
+		"action":        "debug",
+		"automation_id": "automation.morning_routine",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Must not return an error result — GetState failure is best-effort.
+	if result.IsError {
+		t.Errorf("GetState failure should not produce error result: %s", result.Content[0].Text)
+	}
+}
+
 // TestExtractTriggerTypes verifies extraction of deduplicated trigger platform types.
 func TestExtractTriggerTypes(t *testing.T) {
 	t.Parallel()

--- a/internal/handlers/traces_test.go
+++ b/internal/handlers/traces_test.go
@@ -256,6 +256,91 @@ func TestManageTrace_Get(t *testing.T) {
 	}
 }
 
+// TestManageTrace_List_EntityIDFilter verifies that passing entity_id to the list
+// action automatically derives the domain and sets item_id for server-side filtering.
+// Regression test for issue #73: entity_id was silently ignored, causing the WS call
+// to omit domain and return "id @ data['domain']. Got None".
+func TestManageTrace_List_EntityIDFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantDomain  string
+		wantItemID  string
+		wantError   bool
+		wantContain string
+	}{
+		{
+			name:       "entity_id automation prefix derives domain and item_id",
+			args:       map[string]any{"action": "list", "entity_id": "automation.ev_charging"},
+			wantDomain: "automation",
+			wantItemID: "automation.ev_charging",
+		},
+		{
+			name:       "entity_id script prefix derives domain and item_id",
+			args:       map[string]any{"action": "list", "entity_id": "script.morning_routine"},
+			wantDomain: "script",
+			wantItemID: "script.morning_routine",
+		},
+		{
+			name:        "entity_id conflicts with explicit domain",
+			args:        map[string]any{"action": "list", "entity_id": "automation.foo", "domain": "script"},
+			wantError:   true,
+			wantContain: "domain",
+		},
+		{
+			name:        "entity_id with unknown prefix returns validation error",
+			args:        map[string]any{"action": "list", "entity_id": "light.living_room"},
+			wantError:   true,
+			wantContain: "entity_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedData map[string]any
+			client := &UniversalMockClient{
+				SendHACSCommandFn: func(_ context.Context, cmd string, data map[string]any) (any, error) {
+					if cmd != "trace/list" {
+						return nil, fmt.Errorf("wrong command: %s", cmd)
+					}
+					capturedData = data
+					return []any{}, nil
+				},
+			}
+
+			handler := NewTraceHandlers()
+			result, err := handler.HandleManageTrace(context.Background(), client, tt.args)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantError {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", result.Content[0].Text)
+				}
+				if tt.wantContain != "" && !contains(result.Content[0].Text, tt.wantContain) {
+					t.Errorf("error text does not contain %q: %s", tt.wantContain, result.Content[0].Text)
+				}
+				return
+			}
+
+			if result.IsError {
+				t.Fatalf("unexpected error result: %s", result.Content[0].Text)
+			}
+			if capturedData["domain"] != tt.wantDomain {
+				t.Errorf("data[domain] = %v, want %q", capturedData["domain"], tt.wantDomain)
+			}
+			if capturedData["item_id"] != tt.wantItemID {
+				t.Errorf("data[item_id] = %v, want %q", capturedData["item_id"], tt.wantItemID)
+			}
+		})
+	}
+}
+
 // TestManageTrace_GetMissingParams verifies validation for get action.
 func TestManageTrace_GetMissingParams(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Fixes #74: `manage_trace debug` showed empty `State:` field — the HA config endpoint doesn't return runtime state
- Fixes #73: `manage_trace list` with `entity_id` returned a confusing internal error instead of useful output

## Root Causes

**#74:** `fetchDebugAutomationConfig` called `GetAutomation` (config endpoint only) and read `auto.State`, which is always empty from that endpoint. Runtime state requires a separate `GetState` call.

**#73:** `handleListTraces` ignored the `entity_id` parameter entirely. When passed without an explicit `domain`, the WS command received no `domain` field and returned `id @ data['domain']. Got None`.

## Fixes

**#74:** `fetchDebugAutomationConfig` now calls `GetState` after `GetAutomation`. Best-effort: if `GetState` fails, `State` stays empty rather than failing the whole debug report.

**#73:** `handleListTraces` now processes `entity_id` for the list action:
- Derives `domain` from prefix (`automation.foo` → `automation`)
- Validates prefix (only `automation`/`script` supported)
- Checks for conflicts with explicit `domain` parameter
- Sets `item_id` for server-side filtering
- Logic extracted into `resolveTraceListParams` to satisfy gocyclo limit

## Test plan

- [x] `TestHandleDebugTrace_StateFromGetState` — GetAutomation returns `State=""`, GetState returns `"on"`, output contains `State: on`
- [x] `TestHandleDebugTrace_StateGetStateFails` — GetState error is swallowed, no error result returned
- [x] `TestManageTrace_List_EntityIDFilter/entity_id_automation_prefix_derives_domain_and_item_id`
- [x] `TestManageTrace_List_EntityIDFilter/entity_id_script_prefix_derives_domain_and_item_id`
- [x] `TestManageTrace_List_EntityIDFilter/entity_id_conflicts_with_explicit_domain`
- [x] `TestManageTrace_List_EntityIDFilter/entity_id_with_unknown_prefix_returns_validation_error`
- [x] Full handler suite passes (`go test ./internal/handlers/`)
- [x] Linter clean (`task lint`)