### PR TITLE
fix(patch): robust operations parser + error enrichment roll-out

### DIFF
--- a/internal/handlers/automations.go
+++ b/internal/handlers/automations.go
@@ -4,7 +4,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -989,51 +988,7 @@ func isValidSlugID(id string) bool {
 }
 
 // enrichAutomationError appends actionable hints when HA returns a 400 validation
-// error for automation create/update/patch operations. Returns the original message
-// unchanged when no matching hint is found.
+// error for automation create/update/patch operations. Delegates to enrichConfigError.
 func enrichAutomationError(msg string, err error) string {
-	var apiErr *homeassistant.APIError
-	if !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
-		return msg
-	}
-
-	body := strings.ToLower(apiErr.Message)
-
-	for _, hint := range automationErrorHints {
-		if strings.Contains(body, hint.pattern) {
-			return msg + "\n\nHint: " + hint.suggestion
-		}
-	}
-
-	return msg
-}
-
-// automationErrorHint maps a pattern found in HA 400-error bodies to an actionable suggestion.
-type automationErrorHint struct {
-	pattern    string
-	suggestion string
-}
-
-//nolint:gochecknoglobals // static lookup table for error enrichment
-var automationErrorHints = []automationErrorHint{
-	{
-		pattern:    "extra keys not allowed",
-		suggestion: "The config contains an unrecognized key. Common mistakes: (1) 'sun' condition does not exist — use {\"condition\": \"state\", \"entity_id\": \"sun.sun\", \"state\": \"above_horizon\"} instead. (2) Check that trigger/condition/action keys match the HA schema for that type.",
-	},
-	{
-		pattern:    "required key not provided",
-		suggestion: "A required field is missing. Triggers need 'trigger' (type) key; conditions need 'condition' key; actions need 'action' (service) key.",
-	},
-	{
-		pattern:    "expected a list",
-		suggestion: "The 'trigger', 'condition', or 'automation_action' field must be an array (list), not a single object.",
-	},
-	{
-		pattern:    "unable to find action",
-		suggestion: "The service name in 'action' may be wrong. Use 'domain.service' format, e.g. 'light.turn_on', 'notify.mobile_app'. Check available services with call_service tool.",
-	},
-	{
-		pattern:    "invalid template",
-		suggestion: "Template syntax error. HA uses Jinja2: {{ states('sensor.x') }}, {{ is_state('entity', 'on') }}, etc.",
-	},
+	return enrichConfigError(msg, err, automationErrorHints)
 }

--- a/internal/handlers/automations_test.go
+++ b/internal/handlers/automations_test.go
@@ -2375,13 +2375,14 @@ func TestEnrichAutomationError(t *testing.T) {
 			wantExact: "Error creating automation: server error",
 		},
 		{
+			// data['which'] now matches the specific rule (before the generic "extra keys" rule).
 			name: "extra keys not allowed triggers hint",
 			msg:  "error saving patched automation: Home Assistant API error (status 400): invalid automation config: {\"message\":\"Message malformed: extra keys not allowed @ data['which']\"}",
 			err: &homeassistant.APIError{
 				StatusCode: 400,
 				Message:    "invalid automation config: {\"message\":\"Message malformed: extra keys not allowed @ data['which']\"}",
 			},
-			wantContain: "sun' condition does not exist",
+			wantContain: "'which' is not a valid key for the sun condition",
 		},
 		{
 			name: "required key not provided triggers hint",

--- a/internal/handlers/error_enrichment.go
+++ b/internal/handlers/error_enrichment.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+)
+
+// configErrorHint maps a substring found in HA 400-error bodies to an actionable suggestion.
+type configErrorHint struct {
+	pattern    string
+	suggestion string
+}
+
+// enrichConfigError appends an actionable hint when HA returns a 400 validation
+// error whose body matches one of the provided hint patterns. Returns the original
+// message unchanged when no match is found or the error is not a 400 APIError.
+func enrichConfigError(msg string, err error, hints []configErrorHint) string {
+	var apiErr *homeassistant.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
+		return msg
+	}
+	body := strings.ToLower(apiErr.Message)
+	for _, hint := range hints {
+		if strings.Contains(body, hint.pattern) {
+			return msg + "\n\nHint: " + hint.suggestion
+		}
+	}
+	return msg
+}
+
+//nolint:gochecknoglobals // static lookup tables for error enrichment
+
+var automationErrorHints = []configErrorHint{
+	{
+		// Specific match before the generic "extra keys not allowed" catch-all.
+		pattern:    "data['which']",
+		suggestion: "'which' is not a valid key for the sun condition. Use: {\"condition\": \"state\", \"entity_id\": \"sun.sun\", \"state\": \"above_horizon\"} or \"below_horizon\" instead.",
+	},
+	{
+		pattern:    "extra keys not allowed",
+		suggestion: "The config contains an unrecognized key. Common mistakes: (1) 'sun' condition does not exist — use {\"condition\": \"state\", \"entity_id\": \"sun.sun\", \"state\": \"above_horizon\"} instead. (2) Check that trigger/condition/action keys match the HA schema for that type.",
+	},
+	{
+		pattern:    "required key not provided",
+		suggestion: "A required field is missing. Triggers need 'trigger' (type) key; conditions need 'condition' key; actions need 'action' (service) key.",
+	},
+	{
+		pattern:    "expected a list",
+		suggestion: "The 'trigger', 'condition', or 'automation_action' field must be an array (list), not a single object.",
+	},
+	{
+		pattern:    "unable to find action",
+		suggestion: "The service name in 'action' may be wrong. Use 'domain.service' format, e.g. 'light.turn_on', 'notify.mobile_app'. Check available services with call_service tool.",
+	},
+	{
+		pattern:    "invalid template",
+		suggestion: "Template syntax error. HA uses Jinja2: {{ states('sensor.x') }}, {{ is_state('entity', 'on') }}, etc.",
+	},
+}
+
+var scriptErrorHints = []configErrorHint{
+	{
+		pattern:    "extra keys not allowed",
+		suggestion: "The script config contains an unrecognized key. Script actions use the 'action' key (not 'service'). Check that all sequence step keys match the HA schema.",
+	},
+	{
+		pattern:    "required key not provided",
+		suggestion: "A required field is missing from the script config. Each sequence step needs an 'action' key.",
+	},
+	{
+		pattern:    "invalid template",
+		suggestion: "Template syntax error in script. HA uses Jinja2: {{ states('sensor.x') }}, {{ is_state('entity', 'on') }}, etc.",
+	},
+}
+
+var sceneErrorHints = []configErrorHint{
+	{
+		pattern:    "extra keys not allowed",
+		suggestion: "The scene config contains an unrecognized key. Entity entries use 'state' and attribute keys only — remove any unknown fields.",
+	},
+	{
+		pattern:    "required key not provided",
+		suggestion: "A required field is missing from the scene config. Each entity entry needs at least a 'state' field.",
+	},
+}

--- a/internal/handlers/patch.go
+++ b/internal/handlers/patch.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/zorak1103/ha-mcp/internal/jsonpatch"
 	"github.com/zorak1103/ha-mcp/internal/mcp"
@@ -58,6 +59,37 @@ func patchOperationsSchema() mcp.JSONSchema {
 	}
 }
 
+// toAnySlice normalises various slice representations to []any.
+// Accepts []any (standard JSON decode), json.RawMessage (pre-encoded arguments),
+// and any other slice type via JSON round-trip (e.g. []map[string]any).
+func toAnySlice(v any) ([]any, error) {
+	if s, ok := v.([]any); ok {
+		return s, nil
+	}
+	// Pre-encoded JSON bytes from clients that defer argument parsing.
+	if raw, ok := v.(json.RawMessage); ok {
+		var result []any
+		if err := json.Unmarshal(raw, &result); err != nil {
+			return nil, fmt.Errorf("operations must be a JSON array; got json.RawMessage that failed to parse: %w", err)
+		}
+		return result, nil
+	}
+	// Typed slices (e.g. []map[string]any) from internal callers or custom decoders.
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("operations must be a JSON array; got %T", v)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("operations must be a JSON array; could not normalise %T: %w", v, err)
+	}
+	var result []any
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, fmt.Errorf("operations must be a JSON array; normalisation of %T failed: %w", v, err)
+	}
+	return result, nil
+}
+
 // parseOperations extracts and validates operations from MCP args.
 // Returns nil result on success; returns an error result on validation failure.
 func parseOperations(args map[string]any) ([]SemanticOperation, *mcp.ToolsCallResult) {
@@ -66,9 +98,9 @@ func parseOperations(args map[string]any) ([]SemanticOperation, *mcp.ToolsCallRe
 		return nil, errorResult("operations is required for patch action")
 	}
 
-	rawSlice, ok := raw.([]any)
-	if !ok {
-		return nil, errorResult("operations must be an array")
+	rawSlice, err := toAnySlice(raw)
+	if err != nil {
+		return nil, errorResult(err.Error())
 	}
 	if len(rawSlice) == 0 {
 		return nil, errorResult("operations must contain at least one operation")

--- a/internal/handlers/patch_semantic.go
+++ b/internal/handlers/patch_semantic.go
@@ -9,6 +9,13 @@ import (
 	"github.com/zorak1103/ha-mcp/internal/jsonpatch"
 )
 
+// Patch operation type constants used for semantic op validation.
+const (
+	patchOpAdd     = "add"
+	patchOpReplace = "replace"
+	patchOpTest    = "test"
+)
+
 // SemanticOperation extends jsonpatch.Operation with optional property-based addressing.
 // When Match is non-nil, the operation targets elements found by matching properties
 // rather than by numeric index. Path must be empty when Match is set.
@@ -165,7 +172,7 @@ func validateSemanticOp(op SemanticOperation, idx int) error {
 	if op.Op == arrayModeRemove && op.Field != "" {
 		return fmt.Errorf("'field' must be empty for 'remove' operations with semantic match (operation %d)", idx)
 	}
-	needsField := op.Op == "replace" || op.Op == "add" || op.Op == "test"
+	needsField := op.Op == patchOpReplace || op.Op == patchOpAdd || op.Op == patchOpTest
 	if needsField && op.Field == "" {
 		return fmt.Errorf("'field' is required for %q operations with semantic match (operation %d)", op.Op, idx)
 	}

--- a/internal/handlers/patch_test.go
+++ b/internal/handlers/patch_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/zorak1103/ha-mcp/internal/homeassistant"
@@ -26,7 +27,7 @@ func TestParseOperations(t *testing.T) {
 			name:        "operations not array",
 			args:        map[string]any{"operations": "notarray"},
 			wantNilOps:  true,
-			wantErrFrag: "operations must be an array",
+			wantErrFrag: "operations must be a JSON array",
 		},
 		{
 			name:        "empty operations",
@@ -323,5 +324,126 @@ func TestParseOperations_RoundTrip(t *testing.T) {
 	conditions := resultMap["conditions"].([]any)
 	if len(conditions) != 0 {
 		t.Errorf("len(conditions) = %d, want 0", len(conditions))
+	}
+}
+
+// TestParseOperations_AlternativeInputTypes verifies that parseOperations accepts
+// operations encoded as json.RawMessage or []map[string]any in addition to []any.
+// Regression test for issue #75: MCP clients that pre-encode arguments may deliver
+// the operations array as json.RawMessage, causing a hard type-assertion failure.
+func TestParseOperations_AlternativeInputTypes(t *testing.T) {
+	t.Parallel()
+
+	validOp := map[string]any{"op": "replace", "path": "/mode", "value": "queued"}
+
+	tests := []struct {
+		name         string
+		operations   any
+		wantOpsCount int
+		wantErrFrag  string
+	}{
+		{
+			name:         "json.RawMessage array",
+			operations:   json.RawMessage(`[{"op":"replace","path":"/mode","value":"queued"}]`),
+			wantOpsCount: 1,
+		},
+		{
+			name:         "[]map[string]any",
+			operations:   []map[string]any{{"op": "replace", "path": "/mode", "value": "queued"}},
+			wantOpsCount: 1,
+		},
+		{
+			name:         "[]any (existing happy path still works)",
+			operations:   []any{validOp},
+			wantOpsCount: 1,
+		},
+		{
+			name:        "int - invalid type reports Go type name",
+			operations:  42,
+			wantErrFrag: "int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ops, errResult := parseOperations(map[string]any{"operations": tt.operations})
+
+			if tt.wantErrFrag != "" {
+				if errResult == nil {
+					t.Fatal("expected error result, got nil")
+				}
+				if !containsStrHandlers(errResult.Content[0].Text, tt.wantErrFrag) {
+					t.Errorf("error %q does not contain %q", errResult.Content[0].Text, tt.wantErrFrag)
+				}
+				return
+			}
+
+			if errResult != nil {
+				t.Fatalf("unexpected error: %s", errResult.Content[0].Text)
+			}
+			if len(ops) != tt.wantOpsCount {
+				t.Errorf("len(ops) = %d, want %d", len(ops), tt.wantOpsCount)
+			}
+			if len(ops) > 0 && ops[0].Op != "replace" {
+				t.Errorf("ops[0].Op = %q, want 'replace'", ops[0].Op)
+			}
+		})
+	}
+}
+
+// TestParseOperations_DeepValueObject verifies that a deeply-nested value (e.g. a
+// full choose block) passes through the parser and round-trips to the engine unchanged.
+// Regression test for issue #75: deep value objects were the reported payload.
+func TestParseOperations_DeepValueObject(t *testing.T) {
+	t.Parallel()
+
+	chooseBlock := map[string]any{
+		"choose": []any{
+			map[string]any{
+				"conditions": []any{
+					map[string]any{"condition": "state", "entity_id": "input_text.ev_vehicle", "state": "Unbekannt"},
+				},
+				"sequence": []any{
+					map[string]any{"action": "script.ioniq6_force_refresh"},
+					map[string]any{"variables": map[string]any{"detected": "{{ 'Ioniq 6' }}"}},
+				},
+			},
+		},
+	}
+
+	args := map[string]any{
+		"operations": []any{
+			map[string]any{"op": "add", "path": "/actions/1", "value": chooseBlock},
+		},
+	}
+
+	ops, errResult := parseOperations(args)
+	if errResult != nil {
+		t.Fatalf("unexpected error parsing deep value: %s", errResult.Content[0].Text)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op, got %d", len(ops))
+	}
+
+	// Verify the value round-trips through the engine.
+	doc := map[string]any{
+		"actions": []any{
+			map[string]any{"action": "light.turn_on"},
+			map[string]any{"action": "light.turn_off"},
+		},
+	}
+	result, err := applyPatchWithSemantics(doc, ops)
+	if err != nil {
+		t.Fatalf("applyPatchWithSemantics error: %v", err)
+	}
+	actions, _ := result["actions"].([]any)
+	if len(actions) != 3 {
+		t.Fatalf("expected 3 actions after insert, got %d", len(actions))
+	}
+	inserted, _ := actions[1].(map[string]any)
+	if _, ok := inserted["choose"]; !ok {
+		t.Errorf("inserted action missing 'choose' key; got: %v", inserted)
 	}
 }

--- a/internal/handlers/scenes.go
+++ b/internal/handlers/scenes.go
@@ -304,7 +304,8 @@ func (h *SceneHandlers) handleUpdate(ctx context.Context, client homeassistant.C
 
 	// Use configID (without prefix) for REST API
 	if err := client.UpdateScene(ctx, configID, config); err != nil {
-		return errorResult(fmt.Sprintf("Error updating scene: %v", err)), nil
+		msg := fmt.Sprintf("Error updating scene: %v", err)
+		return errorResult(enrichConfigError(msg, err, sceneErrorHints)), nil
 	}
 
 	return successResult(fmt.Sprintf("Scene '%s' updated successfully", sceneID)), nil
@@ -564,7 +565,8 @@ func (h *SceneHandlers) handlePatch(ctx context.Context, client homeassistant.Cl
 	}
 
 	if err := client.UpdateScene(ctx, configID, newConfig); err != nil {
-		return errorResult(fmt.Sprintf("error saving patched scene: %v", err)), nil
+		msg := fmt.Sprintf("error saving patched scene: %v", err)
+		return errorResult(enrichConfigError(msg, err, sceneErrorHints)), nil
 	}
 
 	return successResult(fmt.Sprintf("Scene '%s' patched successfully (%d operations applied)", sceneID, len(ops))), nil

--- a/internal/handlers/scripts.go
+++ b/internal/handlers/scripts.go
@@ -403,7 +403,8 @@ func (h *ScriptHandlers) handleUpdate(ctx context.Context, client homeassistant.
 
 	// Use configID (without prefix) for REST API
 	if err := client.UpdateScript(ctx, configID, config); err != nil {
-		return errorResult(fmt.Sprintf("Error updating script: %v", err)), nil
+		msg := fmt.Sprintf("Error updating script: %v", err)
+		return errorResult(enrichConfigError(msg, err, scriptErrorHints)), nil
 	}
 
 	return successResult(fmt.Sprintf("Script '%s' updated successfully", scriptID)), nil
@@ -504,7 +505,8 @@ func (h *ScriptHandlers) handlePatch(ctx context.Context, client homeassistant.C
 	}
 
 	if err := client.UpdateScript(ctx, configID, newConfig); err != nil {
-		return errorResult(fmt.Sprintf("error saving patched script: %v", err)), nil
+		msg := fmt.Sprintf("error saving patched script: %v", err)
+		return errorResult(enrichConfigError(msg, err, scriptErrorHints)), nil
 	}
 
 	return successResult(fmt.Sprintf("Script '%s' patched successfully (%d operations applied)", scriptID, len(ops))), nil


### PR DESCRIPTION
## Summary

- Fixes #75: `manage_automation patch` rejects valid `operations` arrays sent as `json.RawMessage` or `[]map[string]any`
- Advances #55: error enrichment extracted into shared helper, rolled out to `manage_script` and `manage_scene`

## Root Causes

**#75:** `parseOperations` used a single hard type-assertion `raw.([]any)`. MCP clients that pre-encode arguments as `json.RawMessage`, or internal callers using typed slices, hit this assertion and receive `"operations must be an array"` even with syntactically valid JSON arrays.

**#55:** `enrichAutomationError` was only wired into automation handlers. Script/scene update and patch paths surfaced raw HA 400 errors without hints.

## Fixes

**#75:** New `toAnySlice()` helper with three branches:
1. `[]any` — fast path, unchanged
2. `json.RawMessage` — `json.Unmarshal` fallback  
3. Any other `reflect.Slice` — JSON round-trip normalisation

Error message now includes the Go type name for easier diagnosis.

**#55:**
- Generic `enrichConfigError(msg, err, hints)` extracted to `error_enrichment.go`
- `automationErrorHints` gains a specific `"data['which']"` pattern (more precise than the generic "extra keys" match) for the sun condition bug
- New `scriptErrorHints` and `sceneErrorHints` tables
- Enrichment wired into `UpdateScript`/patch and `UpdateScene`/patch
- Added `patchOpReplace/Add/Test` constants in `patch_semantic.go` (goconst fix)

## Test plan

- [x] `TestParseOperations_AlternativeInputTypes/json.RawMessage_array`
- [x] `TestParseOperations_AlternativeInputTypes/[]map[string]any`
- [x] `TestParseOperations_AlternativeInputTypes/int_-_invalid_type_reports_Go_type_name`
- [x] `TestParseOperations_DeepValueObject` — choose block passes through unchanged (was already passing; confirms no regression)
- [x] `TestEnrichAutomationError/extra_keys_not_allowed_triggers_hint` updated to expect specific sun/which hint
- [x] Full handler suite (`go test ./internal/handlers/`)
- [x] Linter clean (`task lint`)