### PR TITLE
fix(ci): pin golangci-lint, govulncheck, goreleaser to known-good versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        # renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
       - name: Run lint
         run: task lint
@@ -136,7 +137,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # renovate: datasource=go depName=golang.org/x/vuln
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: task vulncheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          # renovate: datasource=github-releases depName=goreleaser/goreleaser
+          version: v2.15.4
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -77,5 +77,21 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"]
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+run: go install \\S+@(?<currentValue>v\\S+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>v\\S+)"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- `golangci-lint/v2` jumped from **v2.11.4 → v2.12.1** (released 2026-05-01) between the last green `main` run and PR #80, silently breaking every subsequent CI run via `@latest`. The new version ships an updated `goconst` that surfaces 800+ pre-existing literal violations across the handler files.
- Same floating-version trap exists for `govulncheck` and `goreleaser` — pinned in the same PR before they bite.
- Added Renovate `customManagers` regex blocks so all three pins are discovered as tracked dependencies — future updates arrive as reviewable PRs, not surprise regressions.

**Pinned versions** (from last successful runs `25158730492` / `25160089708`):
| Tool | Version |
|------|---------|
| `golangci-lint/v2` | `v2.11.4` |
| `golang.org/x/vuln` (`govulncheck`) | `v1.3.0` |
| `goreleaser` | `v2.15.4` |

**Not in scope:** the 800 `goconst` violations introduced by `v2.12.x`. They surface when Renovate opens the inevitable `golangci-lint v2.12.x` bump PR — at that point we evaluate fixing the violations or relaxing the new `goconst` behaviour.

## Test plan

- [ ] CI `Lint` job shows `go: downloading github.com/golangci/golangci-lint/v2 v2.11.4` (not `v2.12.1`) and passes
- [ ] CI `Security (govulncheck)` job shows `v1.3.0` and passes
- [ ] All four CI jobs (`Lint`, `Test`, `Build`, `Security`) green
- [ ] After merge, trigger Renovate via workflow_dispatch — verify `golangci/golangci-lint`, `golang.org/x/vuln`, and `goreleaser/goreleaser` appear as tracked packages in the Dependency Dashboard issue
- [ ] PR #80 (`renovatebot/github-action` v46.1.13 bump) reruns and passes after this merges