### PR TITLE
fix(ci): bump Go 1.26.2 → 1.26.3 to fix stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # GitHub Actions CI/CD Pipeline for ha-mcp
 # Home Assistant MCP Server
-# Go Version: 1.26.2
+# Go Version: 1.26.3
 
 name: CI
 
@@ -11,7 +11,8 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.26.2"
+  # renovate: datasource=golang-version depName=golang
+  GO_VERSION: "1.26.3"
   CGO_ENABLED: "0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.26.2"
+  # renovate: datasource=golang-version depName=golang
+  GO_VERSION: "1.26.3"
 
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zorak1103/ha-mcp
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/coder/websocket v1.8.14

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,13 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>v\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+GO_VERSION: \"(?<currentValue>\\S+)\""
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Bumps Go from `1.26.2` → `1.26.3` in `go.mod` and both workflow files
- Adds `# renovate: datasource=golang-version depName=golang` marker above `GO_VERSION` in CI/release workflows so future Go patch releases arrive as reviewable Renovate PRs

## CVEs fixed (active call paths confirmed by govulncheck)

| Advisory | Package | Trace |
|----------|---------|-------|
| [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) | `net` — Panic in Dial/LookupPort on Windows NUL byte | `internal/homeassistant/rest_client.go:156` + `internal/mcp/server.go:130` |
| [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918) | `net/http` — Infinite loop in HTTP/2 on bad SETTINGS_MAX_FRAME_SIZE | `internal/homeassistant/rest_client.go:156` |

Both were found failing on Renovate PR #80 (`Security (govulncheck)` job, run 25592911852). `main` is still green only because its last push predates Go 1.26.3's release.

## Renovate strategy note

This follows the same pinning approach from a2c03c4: the new customManager regex matches the `# renovate: datasource=golang-version depName=golang` marker pattern (without `v`-prefix, unlike the existing goreleaser/govulncheck markers) so Renovate can track Go patch versions independently.

## Test plan
- [ ] `Security (govulncheck)` job green — CVEs gone
- [ ] Lint, Test, Build stay green
- [ ] After merge: Renovate PR #80 should rebase and auto-merge cleanly