### PR TITLE
feat(skills): add ha-mcp Claude Code skill bundle

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-efficiency/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-efficiency/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ha-mcp-efficiency
+description: "Use when planning multi-call ha-mcp workflows or when token usage matters. Examples: \"query 50 entities\", \"batch-update labels\", \"reduce response size\", \"avoid unnecessary API calls\"."
+---
+
+# ha-mcp Efficiency
+
+## Always: format=natural
+
+`format=natural` is the default. Never override it unless the caller will programmatically parse JSON.
+
+- Produces LLM-optimized prose — easier to reason about, no schema overhead.
+- 30-60% fewer tokens than `format=json` for most responses.
+- Use `format=json` only when piping output to another tool or doing machine parsing.
+
+## Use query_entities Modes
+
+**Never loop `get_state` N times.** One `query_entities` call replaces all of them.
+
+| Scenario                                           | Mode         | Key params                             |
+| -------------------------------------------------- | ------------ | -------------------------------------- |
+| Browse entities by domain, area, or state          | `current`    | `domain`, `area_id`, `state_filter`    |
+| Find unavailable / unknown / stale entities        | `health`     | `categories`, `include_disabled`       |
+| Who's home? Device trackers / persons              | `presence`   | (none extra)                           |
+| Sensor readings over a time range                  | `history`    | `entity_ids`, `start_time`, `end_time` |
+| Min/max/mean aggregated stats                      | `statistics` | `statistic_ids`, `period`              |
+| What entity domains exist in this HA instance?     | `domains`    | (none)                                 |
+
+## Patch Over Update
+
+For partial changes to automations, scripts, scenes, or dashboards:
+
+| Change type                           | Use      | Why                                              |
+| ------------------------------------- | -------- | ------------------------------------------------ |
+| 1-3 field changes                     | `patch`  | Sends only ops, not full config                  |
+| Adding / removing array elements      | `patch`  | Semantic ops handle position automatically       |
+| Full config rewrite / major restructure | `update` | Simpler when structure changes significantly   |
+
+## get vs. list
+
+| Operation              | Populates Config? | Token cost | Use for                           |
+| ---------------------- | ----------------- | ---------- | --------------------------------- |
+| `list`                 | No                | Low        | Discovery, count, quick scan      |
+| `get`                  | Yes               | Medium     | Before update/patch, full details |
+| `get_details` (helper) | Yes               | Medium     | Full helper config                |
+
+**Rule:** Never patch after a `list`. Always `get` first.
+
+## Smart Wait Is Server-Side
+
+After any mutation (`create`, `update`, `delete`, `patch`, `call_service`):
+
+- The server snapshots state before, mutates, then polls HA until state changes (default: 5s timeout, 100ms interval).
+- Result appends `State changes: entity: old → new` or a timeout warning.
+- **Do not** call `get_state` manually after a mutation — that duplicates server-side polling and adds latency.
+
+## Label / Alias Array Modes
+
+When updating labels or aliases, use modes to avoid sending the full current list:
+
+| mode      | Behavior                                  | When to use                              |
+| --------- | ----------------------------------------- | ---------------------------------------- |
+| `add`     | Appends new items, deduplicates (default) | Adding one label without touching others |
+| `remove`  | Subtracts listed items                    | Removing a specific label                |
+| `replace` | Full replacement                          | Setting the exact final list             |
+
+`label_mode` / `alias_mode` apply only to `update` actions on `manage_entity`, `manage_device`, `manage_area`, `manage_floor`.
+
+## Cache-Aware Reads
+
+If `HA_CACHE_ENABLED=true`, registry reads (`get_registry`, `manage_*:list`) are cached server-side with per-type TTLs (10-60 min). Cache is automatically invalidated after create/update/delete mutations on the same registry type. Do not add client-side caching — the server already prevents thundering-herd via `singleflight`.
+
+## Source for Maintenance
+
+CLAUDE.md sections "Post-Mutation Async Confirmation (Smart Wait)", "Configuration Priority", "Consolidated Tools".

--- a/.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: ha-mcp-gotchas
+description: "Use when a ha-mcp call returns an unexpected result, error, or behaves differently than expected. Examples: \"scene not appearing after create\", \"helper entity_id is wrong\", \"patch failing with missing config\", \"automation ID mismatch\"."
+---
+
+# ha-mcp Gotchas
+
+Look up by symptom. Fix is actionable.
+
+## Trap Lookup
+
+| Symptom                                                   | Cause                                                                     | Fix                                                                                                             |
+| --------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Scene doesn't appear after `create`                       | `scene.reload` via REST is a no-op                                        | Warning is expected and informational. Scene requires full HA restart to appear.                                |
+| `patch` returns "missing field" / wrong base on automation | `list` does not populate the Config field                                 | Call `manage_automation:get` first; patch using the returned full Config as reference.                          |
+| Helper has wrong `entity_id` after create                 | WS helpers use `id` param; Config Entry helpers use `name` param          | See helper ID rules table below.                                                                                |
+| `utility_meter`, `statistics`, `trend`, `filter` fail on create | Source entity must be `sensor.*`, not `input_number.*`              | Wrap `input_number` in a `template_sensor` that sources the input value.                                        |
+| `generic_thermostat`, `generic_hygrostat`, `switch_as_x` fail | Source entity must be `switch.*`, not `input_boolean.*`              | Wrap `input_boolean` in a `template_binary_sensor` with `turn_on`/`turn_off` service actions.                   |
+| `manage_trace:list` returns error about missing field     | `domain` param is required despite schema marking it optional             | Always pass `domain: "automation"` or `domain: "script"`.                                                       |
+| `manage_blueprint:import` returns 4xx                     | HA blocks non-public URLs — loopback/link-local/private IPs rejected      | URL must be a public `https://` address. No local URLs.                                                         |
+| Todo `update_item` or `remove_item` fails                 | User param `uid` maps internally to API field `item`                      | Pass `uid` in tool args — the mapping to `item` is done by the handler. Never pass `item` directly.             |
+| HACS `download` action fails with unknown field           | Wrong field name — uses `repository`, not `repository_id`                 | Pass `repository` (the repo path, e.g. `hacs-integrations/hacs`).                                              |
+| Automation `update` creates a duplicate entity            | UI-created automations have numeric config IDs differing from entity slug  | Always call `manage_automation:get` first; use `current.Config.ID` for REST updates.                            |
+| Empty array `[]` rejected on `create`                     | Create validates non-empty required arrays                                | Omit the field or pass a semantic placeholder. Empty arrays are only valid on `update` (to clear).              |
+| Helper `update` silently reverts to old values            | WebSocket helpers require ALL mandatory fields on every update             | Include all required fields: `name` always required, plus type-specific combos (e.g., `min`+`max` for `input_number`). |
+| Label or alias didn't change after `update`               | Default `label_mode`/`alias_mode` is `add`, not `replace`                 | Pass `label_mode: "replace"` or `alias_mode: "replace"` for full overwrite.                                     |
+| Entity ID doesn't match alias/name after create           | HA slugifies `alias`/`name` to derive entity_id; strips non-ASCII chars   | Use ASCII alias, or pass `automation_id` to override the slug explicitly.                                       |
+| Script `update` loses fields (sequence, fields, etc.)     | `get_state` returns only state + friendly_name, not full script config     | Always call `manage_script:get` (uses `GetScript()`), never derive config from a state call.                    |
+| Coverage action returns empty even for active automations | Requires at least one automation with triggers using the target entity     | Expected behavior — no coverage data = target not referenced.                                                   |
+
+## Helper ID Rules
+
+| Helper types                                                                                                                                                               | entity_id controlled by                      |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `input_boolean`, `input_number`, `input_text`, `input_select`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`                                            | `id` parameter (you control the slug)        |
+| `threshold`, `derivative`, `integral`, `group`, `template_sensor`, `template_binary_sensor`, `utility_meter`, `min_max`, `statistics`, `trend`, `random_sensor`, `random_binary_sensor`, `filter`, `tod`, `generic_thermostat`, `generic_hygrostat`, `switch_as_x` | `name` parameter (HA slugifies it — ASCII only) |
+
+## Source for Maintenance
+
+`D:\data\godev\ha-mcp\CLAUDE.md` sections "API & Type Gotchas" and "Pattern Reference".

--- a/.claude/skills/ha-mcp/ha-mcp-guide/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-guide/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ha-mcp-guide
+description: "Use when working with Home Assistant via the ha-mcp MCP server. Examples: \"create automation\", \"toggle light\", \"list entities in living room\", \"patch dashboard\", \"create helper\", \"query sensors\"."
+---
+
+# ha-mcp Guide
+
+Entry point for all ha-mcp work. Read this first, then follow the task-specific skill below.
+
+## When to Use
+
+Whenever the user mentions HA entities, automations, scripts, scenes, helpers, dashboards, areas, devices, services, or anything related to Home Assistant.
+
+## Always Do
+
+- Use `format=natural` for reads — LLM-optimized prose, 30-60% fewer tokens than JSON.
+- Call `manage_*:get` **before** `update` or `patch` — `list` returns summary only, Config is not populated.
+- Use `manage_automation` / `manage_script` / `manage_scene` for CRUD — never `call_service` for lifecycle.
+- Smart Wait is server-side — after mutations the server polls and appends `State changes: entity: old → new` — do not poll manually.
+- All IDs accept entity_id, config UUID, or friendly-name substring — use whichever you have.
+
+## Skills
+
+| Task                                          | Skill               |
+| --------------------------------------------- | ------------------- |
+| Which tool / action to use?                   | `ha-mcp-tools`      |
+| Unexpected error or behavior                  | `ha-mcp-gotchas`    |
+| Edit automation / script / scene / dashboard  | `ha-mcp-patching`   |
+| Reduce tokens or batch operations             | `ha-mcp-efficiency` |
+
+## Tool Cheat Sheet
+
+**Entities**
+- `query_entities` — query all entities by state, domain, area, presence, health, history, statistics (modes: current/history/statistics/domains/presence/health)
+- `query_devices` — device health check (disabled, orphaned, config errors)
+- `get_state` — single entity state + attributes
+- `analyze_entity` — entity usage in automations/scripts/scenes + registry metadata
+- `get_entity_dependencies` — all entities an automation/script depends on
+
+**Registries**
+- `get_registry` — read entities/devices/areas registry in bulk
+- `manage_area` — area CRUD + label/alias modes + include_entities/include_automations on get
+- `manage_entity` — entity registry update/delete (rename, reassign area, labels, aliases)
+- `manage_device` — device registry update/delete (labels, area, disable)
+- `manage_label` / `manage_floor` / `manage_zone` / `manage_person` / `manage_tag` — registry CRUD
+- `manage_config_entry` — list/get config entries (read-only)
+
+**Automations / Scripts / Scenes**
+- `manage_automation` — list/get/create/update/delete/toggle/coverage/patch
+- `manage_script` — list/get/create/update/delete/execute/patch
+- `manage_scene` — list/get/create/update/delete/activate/patch
+
+**Helpers**
+- `manage_helper` — lifecycle for all 26 helper types (list/create/update/delete/get_details)
+- `helper_action` — runtime operations (toggle, set, increment, start, pause, cancel, …)
+
+**Services**
+- `call_service` — call any HA service (use for device control, not CRUD)
+- `list_services` — browse available services with descriptions
+
+**Dashboards / Media / Camera**
+- `manage_dashboard` — dashboard CRUD + patch (match views/cards by title)
+- `browse_media` / `sign_media_path` — media browsing + signed URLs
+- `manage_camera` — snapshot (returns image) or stream (returns URL)
+
+**System / Admin**
+- `get_system_info` / `get_datetime` / `validate_config` / `render_template`
+- `get_logbook` — logbook entries (mode: entries, correlation)
+- `manage_update` — HA and add-on updates (list/release_notes/install/skip)
+- `manage_trace` — automation/script execution traces (list/get/debug)
+- `manage_blueprint` — blueprint list/import (public https:// URL required)
+- `manage_calendar` / `manage_todo` / `manage_hacs`
+
+**Analysis**
+- `analyze_target` — capabilities of a target (triggers/conditions/services/entities/all)

--- a/.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ha-mcp-patching
+description: "Use when editing an existing automation, script, scene, or dashboard with `action: patch`. Examples: \"add a trigger\", \"replace a dashboard card\", \"remove a condition\", \"change automation mode\", \"add delay to trigger\"."
+---
+
+# ha-mcp Patching (JSON Patch + Semantic Patch)
+
+Applies to: `manage_automation`, `manage_script`, `manage_scene`, `manage_dashboard`.
+
+## When to Patch vs. Update
+
+- **Patch**: changing 1-3 fields, modifying array elements (triggers/conditions/actions/views), adding/removing items. Atomic — all ops succeed or none apply.
+- **Update**: rewriting the whole config (major restructure, >5 field changes, or replacing the full action sequence).
+
+## Pre-flight
+
+<EXTREMELY-IMPORTANT>
+Always call `manage_*:get` before patching. `list` does not populate the Config field. Without the full config as reference, your ops have no verified base and may target stale indexes.
+</EXTREMELY-IMPORTANT>
+
+## Standard Ops (RFC 6902 — path-based)
+
+Use `path` as a JSON Pointer (forward-slash syntax). Mutually exclusive with `match`.
+
+| Op        | Effect                                   | Example path                  |
+| --------- | ---------------------------------------- | ----------------------------- |
+| `replace` | Overwrite a field                        | `/mode`, `/alias`             |
+| `add`     | Insert or append                         | `/actions/-` (append to end)  |
+| `remove`  | Delete element or field                  | `/conditions/0`               |
+| `test`    | Assert value (fail if mismatch)          | `/alias`                      |
+| `move`    | Move element (path → to)                | `/triggers/0` → `/triggers/2` |
+| `copy`    | Copy element (path → to)                | `/actions/0` → `/actions/-`   |
+
+```json
+[
+  {"op": "replace", "path": "/mode", "value": "queued"},
+  {"op": "add", "path": "/actions/-", "value": {"service": "notify.mobile_app", "data": {"message": "Done"}}},
+  {"op": "remove", "path": "/conditions/0"}
+]
+```
+
+## Semantic Ops (property-addressed)
+
+Use when array indexes are unreliable — re-ordered, unknown position, or after a previous remove in the same call. Mutually exclusive with `path`.
+
+| Field         | Purpose                                                                      |
+| ------------- | ---------------------------------------------------------------------------- |
+| `match`       | Key-value pairs identifying the target element(s) in the section             |
+| `section`     | Array to search: `triggers`, `conditions`, `actions`, `sequence`, `views`, … |
+| `field`       | Field within the matched element; omit for `remove` (deletes whole element)  |
+| `match_index` | 0-based index when multiple elements match (default: first match)            |
+
+```json
+[
+  {
+    "op": "add",
+    "match": {"entity_id": "binary_sensor.motion", "to": "on"},
+    "section": "triggers",
+    "field": "for",
+    "value": "00:02:00"
+  }
+]
+```
+
+## Worked Snippets
+
+**Replace automation mode:**
+```json
+[{"op": "replace", "path": "/mode", "value": "queued"}]
+```
+
+**Append a new action:**
+```json
+[{"op": "add", "path": "/actions/-", "value": {"service": "light.turn_on", "target": {"entity_id": "light.living_room"}}}]
+```
+
+**Add `for:` delay to a trigger matched by entity_id:**
+```json
+[{"op": "add", "match": {"entity_id": "binary_sensor.door"}, "section": "triggers", "field": "for", "value": "00:05:00"}]
+```
+
+**Remove a condition by match (no `field` = delete whole element):**
+```json
+[{"op": "remove", "match": {"condition": "state", "entity_id": "input_boolean.guest_mode"}, "section": "conditions"}]
+```
+
+**Replace a dashboard view's cards by title:**
+```json
+[{"op": "replace", "match": {"title": "Weather"}, "section": "views", "field": "cards", "value": []}]
+```
+
+**Bulk-replace entity_id across actions:**
+```json
+[{"op": "replace", "match": {"entity_id": "light.old"}, "section": "actions", "field": "entity_id", "value": "light.new"}]
+```
+
+## Atomicity & Ordering
+
+- All operations run as a unit — first failure rolls back all changes.
+- Semantic `remove` ops are automatically sorted descending by index per section — safe to submit multiple removes without index shifting.
+- For standard `path`-based removes, sort descending manually when issuing multiple removes in one call.
+
+## Anti-Patterns
+
+| Instead of…                                          | Do this                                                |
+| ---------------------------------------------------- | ------------------------------------------------------ |
+| Full `update` to change 1-2 fields                   | `patch` with `replace` ops on those fields             |
+| Using `path` index after a remove in the same call   | Use semantic `match` to address elements by property   |
+| Patching without calling `get` first                 | Always `get` first — `list` does not populate Config   |
+| Using both `match` and `path` in the same op         | They are mutually exclusive — pick one per op          |
+
+## Source for Maintenance
+
+`internal/jsonpatch/`, `internal/handlers/patch_semantic.go`, CLAUDE.md section "JSON Patch (RFC 6902) + Semantic Patch".

--- a/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: ha-mcp-tools
+description: "Use when choosing which ha-mcp tool or action to call. Examples: \"How do I list entities?\", \"create a helper\", \"turn on a light\", \"find devices in kitchen\", \"which action should I use?\"."
+---
+
+# ha-mcp Tool Discovery
+
+## Intent → Tool
+
+| User intent                                          | Tool + Action                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| Turn on / off / toggle a device                      | `call_service` (domain=light/switch, service=turn_on/turn_off/toggle)  |
+| Get a single entity's current state                  | `get_state`                                                            |
+| List entities in an area / by domain / by state      | `query_entities` mode=current                                          |
+| Find unavailable / stale / disabled entities         | `query_entities` mode=health                                           |
+| Person / device tracker presence (home/away)         | `query_entities` mode=presence                                         |
+| Historical state for a sensor over time              | `query_entities` mode=history                                          |
+| Aggregated stats (min/max/mean) for a sensor         | `query_entities` mode=statistics                                       |
+| Which entity domains exist in this HA instance?      | `query_entities` mode=domains                                          |
+| Device health (orphaned / config errors)             | `query_devices` mode=health                                            |
+| Where is entity X used? (automations, scripts)       | `analyze_entity`                                                       |
+| Which entities does automation X depend on?          | `get_entity_dependencies`                                              |
+| Create / edit / delete an automation                 | `manage_automation` action=create/update/delete                        |
+| Toggle / enable / disable an automation              | `manage_automation` action=toggle                                       |
+| See automation trigger/condition/service coverage    | `manage_automation` action=coverage                                    |
+| Add/remove a trigger or condition (surgical edit)    | `manage_automation` action=patch (semantic op)                         |
+| Run a script                                         | `manage_script` action=execute                                         |
+| Activate a scene                                     | `manage_scene` action=activate                                         |
+| Create a helper (input, timer, counter, etc.)        | `manage_helper` action=create                                          |
+| Set / toggle / start a helper value at runtime       | `helper_action`                                                        |
+| Rename an entity in the registry                     | `manage_entity` action=update (new_entity_id field)                    |
+| Assign an entity to an area                          | `manage_entity` action=update (area_id field)                          |
+| Add / remove labels on entity or device              | `manage_entity` / `manage_device` action=update + label_mode           |
+| List / create / rename an area                       | `manage_area` action=list/create/update                                |
+| Check what config entries exist for an integration   | `manage_config_entry` action=list (domain filter)                      |
+| Browse available services                            | `list_services`                                                        |
+| Render a Jinja2 template                             | `render_template`                                                      |
+| Get logbook entries / cause-effect correlation       | `get_logbook` mode=entries/correlation                                 |
+| Check HA version / timezone                          | `get_system_info`                                                      |
+| Validate configuration.yaml                          | `validate_config`                                                      |
+| Manage a dashboard (create / edit / view)            | `manage_dashboard`                                                     |
+| Install / uninstall a HACS add-on                    | `manage_hacs` action=download/uninstall                                |
+| View automation / script execution trace             | `manage_trace` action=list/get                                         |
+| Import a blueprint                                   | `manage_blueprint` action=import                                       |
+| Check for HA / add-on updates                        | `manage_update` action=list (pending_only=true)                        |
+| Manage todo list items                               | `manage_todo`                                                          |
+| Manage calendar events                               | `manage_calendar`                                                      |
+
+## Consolidated Tool Action Reference
+
+| Tool                  | Read Actions                                     | Write Actions                                   |
+| --------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| `manage_automation`   | list, get, coverage                              | create, update, delete, toggle, patch           |
+| `manage_script`       | list, get                                        | create, update, delete, execute, patch          |
+| `manage_scene`        | list, get                                        | create, update, delete, activate, patch         |
+| `manage_helper`       | list, get_details                                | create, update, delete                          |
+| `manage_dashboard`    | list, get                                        | create, update, delete, patch                   |
+| `manage_area`         | list, get                                        | create, update, delete                          |
+| `manage_entity`       | get                                              | update, delete                                  |
+| `manage_device`       | get                                              | update, delete                                  |
+| `manage_label`        | list, get                                        | create, update, delete                          |
+| `manage_floor`        | list, get                                        | create, update, delete                          |
+| `manage_zone`         | list, get                                        | create, update, delete                          |
+| `manage_person`       | list, get                                        | create, update, delete                          |
+| `manage_tag`          | list, get                                        | create, update, delete                          |
+| `manage_config_entry` | list, get                                        | (none — read-only)                              |
+| `manage_hacs`         | info, list, get, releases, release_notes, critical | download, uninstall, add_repository, remove_repository, refresh, toggle_beta |
+| `manage_trace`        | list, get, debug                                 | (none — read-only)                              |
+| `manage_blueprint`    | list                                             | import                                          |
+| `manage_update`       | list, release_notes                              | install, skip                                   |
+| `manage_todo`         | list, get_items                                  | add_item, update_item, remove_item              |
+| `manage_calendar`     | list, get_events                                 | create_event, delete_event                      |
+| `query_entities`      | current, history, statistics, domains, presence, health | (none)                                   |
+| `query_devices`       | health                                           | (none)                                          |
+| `analyze_target`      | all, triggers, conditions, services, entities    | (none)                                          |
+| `get_logbook`         | entries, correlation                             | (none)                                          |
+| `helper_action`       | (contextual)                                     | toggle, set, increment, decrement, reset, calibrate, start, pause, cancel, finish, change, press, select, set_options, reload, add_entities, remove_entities |
+
+## Read vs. Write
+
+Access control filter syntax (for `HA_MCP_TOOL_FILTER_WHITELIST` / `_BLACKLIST`):
+
+- `"manage_automation"` — blocks/allows entire tool
+- `"manage_automation:create"` — specific action
+- `"manage_*:delete"` — glob across all manage_ tools
+- `"*:write"` — all write operations (see Write Actions column above)
+
+`read_only: true` is shorthand for blacklisting `*:write`. Whitelist and blacklist are mutually exclusive.
+
+## query_entities Mode Guide
+
+| Mode         | Use when                                                         |
+| ------------ | ---------------------------------------------------------------- |
+| `current`    | Browse entities by domain/area/state — general listing           |
+| `history`    | Sensor/entity state over time (requires time range)              |
+| `statistics` | Aggregated stats (min/max/mean) for sensor entities              |
+| `domains`    | Discover which entity domains exist in this HA instance          |
+| `presence`   | Person/device tracker home/away status                           |
+| `health`     | Find unavailable, unknown, disabled, orphaned, or stale entities |
+
+<EXTREMELY-IMPORTANT>
+Never loop `get_state` for multiple entities. Use `query_entities` with a domain/area filter instead. A single `query_entities` call replaces N×`get_state` calls.
+</EXTREMELY-IMPORTANT>
+
+## Anti-Patterns
+
+| Instead of…                                           | Do this                                               |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| `call_service` to create/update/delete an automation  | `manage_automation` action=create/update/delete       |
+| Multiple `get_state` calls for a set of entities      | `query_entities` mode=current with domain/area filter |
+| Patching after a `list` response                      | Call `get` first — `list` does not populate Config    |
+
+## Source for Maintenance
+
+`D:\data\godev\ha-mcp\docs\tools.md`, `internal/handlers/register.go`, `internal/mcp/access_control.go`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # GitHub Actions CI/CD Pipeline for ha-mcp
 # Home Assistant MCP Server
-# Go Version: 1.26.2
+# Go Version: 1.26.3
 
 name: CI
 
@@ -11,7 +11,8 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.26.2"
+  # renovate: datasource=golang-version depName=golang
+  GO_VERSION: "1.26.3"
   CGO_ENABLED: "0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.26.2"
+  # renovate: datasource=golang-version depName=golang
+  GO_VERSION: "1.26.3"
 
 jobs:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,9 @@ tmp/
 *.prof
 *.pprof
 
-.claude/
+.claude/settings.json
+.claude/settings.local.json
+.claude/skills/gitnexus/
 AGENTS.md
 .mcp.json
-CLAUDE.md
 .reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,423 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ha-mcp is a Model Context Protocol (MCP) server that provides AI assistants with access to Home Assistant. It uses a hybrid architecture: WebSocket for most operations, REST API for automation/script/scene CRUD (create/update/delete). Translates MCP tool calls into Home Assistant API commands.
+
+**Requirements:** Go 1.26+, golangci-lint v2
+
+## Build and Development Commands
+
+> No Makefile — use `task` (Taskfile.yml) exclusively. Install: https://taskfile.dev/#/installation
+
+```bash
+# List all available tasks
+task --list
+
+# Build and test
+task build                  # go build -o ha-mcp[.exe] ./cmd/ha-mcp
+task test                   # go test ./... (no race detector, Windows-safe)
+task test:race              # go test -race ./... (CGO_ENABLED=1, Linux/CI)
+task test:coverage          # race + coverprofile + per-file 80% enforcement
+task test:integration       # go test -tags=integration -v ./internal/handlers/integration/...
+
+# Run specific test directly (not wrapped in a task)
+go test -v ./internal/handlers -run TestSpecificName
+
+# Integration tests with env file
+set -a && source .env.integration && set +a && task test:integration
+
+# Linting
+task lint                   # golangci-lint run --timeout=5m ./...
+task lint:integration       # golangci-lint run --timeout=5m --build-tags=integration ...
+task fmt                    # gofmt -l . (check)
+task fmt:fix                # gofmt -w . (auto-fix)
+
+# Security & analysis
+task vulncheck              # govulncheck ./...
+task deadcode               # deadcode -test ./...  (install: go install golang.org/x/tools/cmd/deadcode@latest)
+
+# Dev server
+task run                    # go run ./cmd/ha-mcp (set HA_URL and HA_TOKEN env vars)
+
+# Release
+task release:snapshot       # goreleaser release --snapshot --clean --skip=publish
+
+# Docker
+docker pull zorak1103/ha-mcp:latest
+docker run -p 8080:8080 -e HA_URL=http://homeassistant.local:8123 zorak1103/ha-mcp:latest
+```
+
+## Architecture
+
+### Request Flow
+
+```
+AI Client (Claude, Cline)
+    → HTTP POST / (JSON-RPC)
+    → MCP Server (internal/mcp/server.go)
+    → Tool Registry lookup (internal/mcp/registry.go)
+    → Tool Handler (internal/handlers/*.go)
+    → HybridClient (internal/homeassistant/hybrid_client.go)
+        → WebSocket (most operations) OR REST API (automation/script/scene CRUD)
+    → Home Assistant API
+```
+
+### Key Packages
+
+- **cmd/ha-mcp**: CLI entry point using Cobra, handles flags and signals
+- **internal/mcp**: MCP protocol server, JSON-RPC handling, tool/resource registry
+- **internal/homeassistant**: Hybrid client (WS + REST), WebSocket with auto-reconnect, REST for automation/script/scene CRUD
+- **internal/handlers**: MCP tool handlers organized by domain (entities, automations, helpers, analysis, config_entries, media, dashboards, statistics, services, templates, etc.)
+- **internal/handlers/formatter**: Output formatting (natural language for LLMs, JSON for backward compatibility)
+- **internal/jsonpatch**: RFC 6902 JSON Patch engine - generic patch operations on `any` types with atomicity via deep clone
+- **internal/config**: Viper-based config loading (YAML → .env → ENV → CLI flags)
+- **internal/logging**: Structured logging with DEBUG/INFO/WARN/ERROR/TRACE levels
+
+### Key Files
+
+**Core infrastructure:**
+- `cmd/ha-mcp/main.go` - Entry point; `internal/handlers/register.go` - central tool registration
+- `internal/mcp/access_control.go` - read/write classification; `internal/mcp/tool_filter.go` - ToolFilterEngine; `internal/mcp/registry.go` - tool registry
+- `internal/homeassistant/client.go` - Client interface; `hybrid_client.go` - primary implementation; `cached_client.go` - caching wrapper
+
+**Domain handlers** follow naming `handlers/{domain}.go` → `manage_{domain}` tool. Exceptions:
+- `entities.go` → `get_state`
+- `analysis.go` → `analyze_entity`, `get_entity_dependencies`
+- `entities_consolidated.go` → `query_entities`; `devices_consolidated.go` → `query_devices`
+- `targets_consolidated.go` → `analyze_target`; `registry_consolidated.go` → `get_registry`
+- `entities_manage.go` → `manage_entity`; `devices_manage.go` → `manage_device`
+
+Extended logic in dedicated `*_coverage.go`, `*_presence.go`, `*_correlation.go`, `*_health.go` files.
+
+### Handler Pattern
+
+Each handler domain follows this pattern:
+1. Create handler struct with `New*Handlers()` factory
+2. Implement `RegisterTools(registry *mcp.Registry)` method
+3. Register in `internal/handlers/register.go` via `RegisterAllTools()`
+
+Tool handlers have signature:
+```go
+func(ctx context.Context, client homeassistant.Client, args map[string]any) (*mcp.ToolsCallResult, error)
+```
+
+**Create-then-update pattern**: For controlling immutable entity IDs (e.g., Helper creation):
+1. Create entity with desired ID as `name` (controls slug)
+2. Immediately update with correct display name
+3. Pattern used in `createWSHelper()` for WebSocket-based entities
+
+**Cache Invalidation Pattern**: New mutation operations (create/update/delete) must invalidate related caches in `cached_client.go` (e.g., area CRUD → `invalidateAreaRegistryCache()`)
+
+**Config Entry Flow Multi-Step Pattern**: Some Config Entry platforms require multiple form submissions beyond initial menu step:
+- `statistics`: 3-step flow (state_characteristic menu → options form → user form) - each step requires different field subset
+- `trend`: settings step excludes "name" field (only entity_id + options)
+- `filter`: 2-step flow (user form with filter type → filter-specific form with entity_id only)
+- Implementation: `buildConfigForFlowStep()` maps step_id to required fields, `createHelperViaConfigFlow()` loops until create_entry
+- threshold, derivative, integration, group, template use HTTP-based Config Entry Flow (automatically handled by HybridClient)
+
+**Config Entry API Field Mapping**: Some platforms use different API field names than user-facing names:
+- `generic_thermostat`: heater_entity_id → heater, target_sensor_entity_id → target_sensor, ac_mode required
+- `generic_hygrostat`: humidifier_entity_id → humidifier, target_sensor_entity_id → target_sensor, device_class required
+- Mapping done in config builders, original fields filtered by `platformSkipFields` map in `shouldSkipConfigField()`
+
+**Config Entry Source Entity Requirements**: Many Config Entry helpers validate source entity domains:
+- utility_meter, statistics, trend, filter require sensor entities (not input_number) - use template sensor wrapper
+- generic_thermostat, generic_hygrostat, switch_as_x require switch entities (not input_boolean) - use template switch wrapper
+- Integration tests: Create helper functions (createSourceSensor, createSourceSwitch) that build input + template wrapper
+
+### Home Assistant Client Interface
+
+The `homeassistant.Client` interface abstracts all HA operations. Implementation uses a hybrid approach:
+- **HybridClient** (`hybrid_client.go`): Routes to WebSocket or REST based on operation type
+- **WebSocket** (`ws_client_impl.go`): Persistent connection with auto-reconnect (1s → 60s backoff)
+- **REST** (`rest_client.go`): Used for automation/script/scene CRUD operations
+- **Retry** (`retry.go`): Automatic retries with exponential backoff for transient failures (5xx, 429, network errors)
+- **CachedClient** (`cached_client.go`): Optional caching layer for static data (services, config, registries)
+  - Uses `golang.org/x/sync/singleflight` to prevent thundering herd (duplicate concurrent API calls)
+  - Thread-safe with configurable TTLs per cache type
+  - Automatically invalidates registry caches after helper create/delete operations
+
+**API Routing:**
+- WebSocket: Helpers (`manage_helper`, `helper_action`), state queries, service calls, registry access, config entries, HACS (`manage_hacs`)
+- REST: Automation/Script/Scene create/update/delete, template rendering, logbook, config validation
+
+**ID Normalization (Automations/Scripts/Scenes):**
+
+Use `normalize*ID(input)` helpers that return `(entityID, configID)`:
+- **entityID**: Full entity_id with prefix (e.g., `script.morning_routine`) - used for WebSocket operations
+- **configID**: Bare ID without prefix (e.g., `morning_routine`) - used for REST API operations
+- Prevents double-prefix bugs: `script.` + `script.xyz` → `script.script.xyz` ❌
+
+UI-created automations have numeric config IDs differing from entity_id suffix. Always fetch via `GetAutomation()` first, then use `current.Config.ID` for REST operations. Scripts: always use `GetScript()` for updates (returns full config), never `GetState()` (returns only state + friendly_name, causes data loss).
+
+**Consolidated Tools (action-based):**
+
+Tool actions and parameters are defined in the handler schemas. Non-obvious aspects only:
+
+- `manage_automation` create: optional `automation_id` (bare slug e.g. `warme_buro`) overrides the auto-generated ID — needed when alias contains non-ASCII chars (umlauts) that HA's slugifier strips
+- `manage_helper` — 26 types. **WebSocket helpers** (input_*, counter, timer, schedule): `id` controls entity_id via create-then-update; **Config Entry helpers** (threshold, derivative, integral, group, template_*, utility_meter, min_max, statistics, trend, random_*, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat): `name` controls entity_id. Multi-step flows: statistics=3, filter=2, trend settings excludes name
+- `manage_hacs` — actions: list, info, get, releases, release_notes, critical, download, uninstall, add_repository, remove_repository, refresh, toggle_beta. All list filters (search, category, installed_only, pending_update) are client-side
+- All `manage_*` CRUD tools support Smart Wait (post-mutation polling, see below)
+
+**Label/Alias Array Mode (manage_entity, manage_device, manage_area, manage_floor):**
+- `label_mode`/`alias_mode` on `update` action: `'add'` (default, append+dedup), `'remove'` (subtract), `'replace'` (full replacement)
+- `add` and `remove` modes fetch the current registry entry to merge; `replace` sets values directly
+- Implemented in `internal/handlers/array_mode.go` (`applyArrayMode`, `getStringSlice`, `getArrayMode`, `arrayModeSchema`)
+- Modes apply only to `update`; `create` always sets initial values directly
+
+**JSON Patch (RFC 6902) + Semantic Patch:**
+- `manage_automation`, `manage_script`, `manage_scene`, `manage_dashboard` all support `action=patch` with an `operations` array
+- **Standard ops** follow RFC 6902: `{"op": "replace", "path": "/mode", "value": "queued"}`
+- **Semantic ops** use property-based addressing: `{"op": "add", "match": {"entity_id": "binary_sensor.door"}, "section": "triggers", "field": "for", "value": "00:05:00"}`
+  - `match`: key-value pairs to identify element(s) — mutually exclusive with `path`
+  - `section`: array to search (`triggers`, `conditions`, `actions`, `sequence`, `views`, …)
+  - `field`: field within matched element(s) — required for `add`/`replace`/`test`; omit for `remove` (deletes whole element)
+  - `match_index`: optional 0-based index to select specific match when multiple elements match
+  - Semantic remove ops are automatically sorted descending per section to prevent index shifting
+- Supported ops: `add`, `remove`, `replace`, `test` (standard: also `move`, `copy`)
+- Atomic: if any operation fails, the config is not modified
+- Standard paths use RFC 6901 JSON Pointer syntax: `/triggers/0/entity_id`, `/actions/-` (append)
+- Implemented in `internal/jsonpatch/` (RFC 6902 engine) + `internal/handlers/patch_semantic.go` (semantic layer)
+
+**Access Control & Tool Filtering:**
+
+The server supports flexible tool/action filtering for security and capability control:
+
+- **Read-Only Mode**: `read_only: true` or `--read-only` flag blocks all write operations (internally: `blacklist: ["*:write"]`)
+- **Whitelist**: If non-empty, ONLY listed tools/actions allowed (implicit deny-all)
+- **Blacklist**: If whitelist empty, block specific tools/actions (implicit allow-all)
+- **Mutual Exclusion**: Cannot specify both whitelist and blacklist (validation error)
+
+**Filter Syntax**:
+- `"get_state"` - entire tool
+- `"manage_automation:create"` - specific action
+- `"manage_*:delete"` - glob pattern (all manage_* tools' delete actions)
+- `"*:write"` - category expansion (all write operations)
+- `"manage_entity:delete"` - specific action on manage_entity
+
+**Implementation**: `ToolFilterEngine` in `internal/mcp/tool_filter.go` with static classification in `internal/mcp/access_control.go` (34 tools, read/write per action). `ValidateFilterConfig()` runs at startup before engine creation — rejects unknown tools, typos, and removed sub-actions with a combined error listing all problems at once (server refuses to start). Three-stage enforcement: startup config validation → registry filtering (removes/modifies tools) → runtime check (blocks calls).
+
+**Post-Mutation Async Confirmation (Smart Wait):**
+- **Pattern**: snapshot before → mutate → poll until changed or timeout → append state diff/warning to success message. Timeout → warning appended, never an error
+- `automation.reload` + `script.reload` ✅ make REST-created entities appear
+- `scene.reload` ❌ does NOT work — scenes require full HA restart after REST creation
+- `call_service`: snapshots target entities before, polls for state changes after, appends "\nState changes: entity: old → new" or warning
+- **Config**: Env vars `HA_WAIT_TIMEOUT_MS` (default: 5000), `HA_WAIT_POLL_INTERVAL_MS` (default: 100). Injected via `mcp.WithWaitConfig(ctx, cfg)` → `mcp.WaitConfigFromContext(ctx)` in handlers
+
+### Configuration Priority
+
+`CLI flags > ENV vars > .env file > config.yaml > defaults`
+
+Key environment variables:
+- **Connection**: `HA_URL`, `HA_TOKEN`, `HA_MCP_PORT`, `HA_MCP_LOG_LEVEL`
+- **Access Control**: `HA_MCP_READ_ONLY`, `HA_MCP_TOOL_FILTER_WHITELIST`, `HA_MCP_TOOL_FILTER_BLACKLIST`
+- **REST Rate Limiting**: `HA_REST_RATE_LIMIT`, `HA_REST_RATE_BURST`
+- **REST Retry**: `HA_REST_MAX_RETRIES` (default: 3), `HA_REST_RETRY_INITIAL_DELAY_MS` (default: 100), `HA_REST_RETRY_MAX_DELAY_MS` (default: 5000)
+- **WebSocket Retry**: `HA_WS_MAX_RETRIES` (default: 3), `HA_WS_RETRY_INITIAL_DELAY_MS` (default: 100), `HA_WS_RETRY_MAX_DELAY_MS` (default: 5000)
+- **Caching**: `HA_CACHE_ENABLED` (default: false), `HA_CACHE_SERVICES_TTL_MIN` (default: 60), `HA_CACHE_CONFIG_TTL_MIN` (default: 30), `HA_CACHE_ENTITY_REG_TTL_MIN` (default: 10), `HA_CACHE_DEVICE_REG_TTL_MIN` (default: 10), `HA_CACHE_AREA_REG_TTL_MIN` (default: 30)
+- **Post-mutation polling**: `HA_WAIT_TIMEOUT_MS` (default: 5000), `HA_WAIT_POLL_INTERVAL_MS` (default: 100)
+
+## Coding Rules
+
+### Linter Rules
+
+- **goconst**: Extract strings repeated 3+ times to package-level constants (e.g., `const usedInAction = "action"`)
+  - Switch case literals must use constants (e.g., `case helperActionUpdate:` not `case "update":`); Enum array literals don't need to
+  - Naming convention: `<handler>Action<Verb> = "<verb>"` (e.g., `helperActionUpdate`, `areaActionUpdate`) — each handler file defines its own even if the value is shared
+- **funlen**: Functions >60 lines fail - extract helper methods or separate schema builders (e.g., `buildEntityManageSchema()`)
+- **gocognit**: Cognitive complexity >23 - extract helpers by operation type: `navigate*()`, `find*()`, `shouldInclude*()`. Pure functions (no ctx/client params) reduce complexity most effectively
+- **staticcheck**: Error messages must be lowercase (`fmt.Errorf("error creating: %w"` not `Error creating`)
+- **gocritic importShadow**: Use parameter names that don't shadow imported packages (e.g., `cfg` instead of `config` when `internal/config` is imported)
+- **gocritic appendCombine**: Combine consecutive appends into single multi-value: `parts = append(parts, a, b, c)` not separate `append()` calls
+- **revive unused-parameter**: In test mocks, omit parameter names entirely (`func(context.Context, string)`) instead of underscore
+- **revive redefines-builtin-id**: Avoid variable names that shadow Go built-in functions (`min`, `max`, `len`, `copy`, `close`) - use suffixed names (`minVal`, `maxVal`)
+- **No trivial wrappers**: Never wrap stdlib functions - use stdlib directly
+
+### API & Type Gotchas
+
+- **Pagination**: `PaginationMetadata.NextCursor` is `*string` - requires nil check and dereferencing
+- **Person attributes**: `device_trackers` is `[]any` requiring type assertion, not `[]string`
+- **Client interface method additions**: When adding methods to `Client` interface, must update 12 files total: (1) client.go interface, (2-3) ws_client_impl.go + rest_client.go implementations, (4-5) hybrid_client.go WSOperations/RESTOperations interfaces + delegation, (6) cached_client.go delegation, (7-12) 6 test mock files (testing_helpers_test.go, server_test.go, cached_client_test.go, factory_test.go, client_pool_test.go, hybrid_client_test.go)
+- **wsClientImpl REST-only method stubs**: When adding REST-only methods to Client interface, `wsClientImpl` needs stub returning informative error
+- **ContentBlock custom MarshalJSON**: `ContentBlock` has a `MarshalJSON` method in `internal/mcp/types.go` that emits only type-specific fields. Do NOT remove it or add `omitempty` back to `Text` — the MCP spec requires `"text"` key always present on text blocks even for empty strings; `omitempty` silently drops it and causes `invalid_union` Zod errors in MCP clients (e.g., `render_template` returning empty string). Uses anonymous struct literals per case to avoid infinite MarshalJSON recursion.
+- **Template helper type field**: `type` field in template config determines sensor vs binary_sensor subtype for Config Entry Flow menu selection, but must be filtered by `shouldSkipConfigField` before API submission
+- **HACS download API field**: `hacs/repository/download` command requires `repository` field (not `repository_id`)
+- **Automation/Scene entity ID derivation**: Home Assistant derives entity IDs from alias/name field (slugified), NOT from config ID. Integration tests: Use matching alias/name and config ID for predictable entity IDs. Handlers: Use `generateAutomationID(alias)` to create matching config IDs
+- **List operations don't populate Config**: `ListAutomations()`, `ListScenes()`, `ListScripts()` return entities with State/EntityID but NOT Config field - use `Get*()` for full config
+- **Trace list API requirement**: `trace/list` WebSocket command requires `domain` parameter (automation or script) - not optional despite handler schema making it optional. Uses `SendHACSCommand` for generic WS dispatch
+- **Todo uid→item API field rename**: User param `uid` maps to `data["item"]` in HA `todo.update_item`/`todo.remove_item` service calls — not `data["uid"]`
+- **Empty array parameter handling**: Distinguish missing array parameter from empty array in validation errors. Create operations reject empty arrays (validation error), update operations allow empty arrays to clear fields. Automation triggers: empty array `[]` auto-fills with manual-only placeholder trigger
+- **Format parameter constants**: Always use existing `formatNatural` (entities_manage.go) and `formatJSON` (areas.go) constants in new tools — avoid hardcoded strings (goconst linter)
+- **MCP Registry API**: Use `registry.RegisterTool(tool, handler)` NOT `registry.AddTool(tool)` (method doesn't exist)
+- **InputSchema type**: Use `mcp.JSONSchema` with `Properties: map[string]mcp.JSONSchema`, NOT `map[string]any`
+
+### Pattern Reference
+
+**Options Flow (config entry options read + write)**: `config_entries/get_single` WS API returns empty Options field. `GetConfigEntryOptions()` initiates Options Flow REST API (init → navigate menu if needed → extract `suggested_value` from `data_schema` → abort). For **updates**: init flow → navigate menu → extract current values via `mergeOptionsFlowConfig()` (preserves unchanged fields) → submit. Template helpers show sensor/binary_sensor menu requiring navigation via `findEntityDomainForConfigEntry()`. See `updateHelperViaOptionsFlow()` in `hybrid_client.go`. Icons are extracted before Options Flow submission and set via Entity Registry after success.
+
+**Helper update routing**: `UpdateHelper` in `HybridClient` checks entity registry for `config_entry_id` — if present, routes to Options Flow REST API; if absent, routes to WebSocket. WebSocket helper updates require **ALL mandatory fields** (not partial): name always required, entity ID without prefix via `ExtractEntityID()`, field combos like input_number needs min+max.
+
+**Entity registry update response**: `UpdateEntityRegistryEntry()` returns the updated `EntityRegistryEntry` (HA wraps response in `entity_entry` key, correctly unwrapped by wsClientImpl); after entity_id rename use `RemoveEntityRegistryEntry()` not `DeleteHelper()`
+
+**Config Entry group cleanup**: Groups created via Config Entry Flow return `unknown_command` for `DeleteHelper` — use `RemoveEntityRegistryEntry()` instead
+
+**Registry tool name resolution**: When adding name-based lookup to registry tools (`manage_*`), use two-phase pattern: `find<Type>ByInput(items, input)` (exact ID → case-insensitive name substring) + `resolve<Type>ID(ctx, client, input)` for update/delete
+
+**Detail map field collisions**: When building detail maps from state attributes, check for field name conflicts with reserved keys (`entity_id`, `state`, `friendly_name`) — rename attribute values to prevent overwriting
+
+## Testing Rules
+
+### Test Coverage Requirements
+
+**Minimum Coverage**: 80% test coverage required for all packages, subject to technical feasibility.
+
+**Integration Test Coverage**: All MCP tools must be covered by integration tests in `internal/handlers/integration/`, subject to technical feasibility. Integration tests verify:
+- API integration against real Home Assistant instance
+- Response parsing and data mapping
+- Error handling with actual API errors
+- Write operations (CRUD) with full lifecycle verification
+- Read operations validate API calls work and responses parse correctly
+
+**Exceptions** (technical infeasibility):
+- Tools requiring external resources not available in test environment (e.g., blueprint `import` action — requires a reachable public https:// URL; private/loopback IPs are blocked by the server-side URL validator)
+- Operations that would affect production state irreversibly (e.g., system restarts)
+- Features requiring specific hardware or integrations not present in test HA instance
+
+**Coverage Verification**:
+```bash
+go test -cover ./internal/handlers
+go test -tags=integration ./internal/handlers/integration
+```
+
+### Unit Test Rules
+
+Test files (`*_test.go`) are excluded from funlen, gocognit, gocyclo, errcheck, gosec, gocritic, govet, goconst, nilnil, and tparallel linters. Shared test utilities are in `internal/handlers/testing_helpers_test.go` (mock clients, result parsing helpers).
+
+- **Backward Compatibility Testing**: When adding new default behaviors (e.g., format parameter), update existing tests to explicitly request old behavior rather than relying on defaults
+- **Service mock hardening**: Blind `CallServiceFn`/`CallServiceWithResponseFn` mocks hide domain/service/field-name bugs. Hardening pattern: `UniversalMockClient` (top-level `t`) → `return nil, fmt.Errorf("wrong domain: %s", domain)` to propagate as handler error; local mock inside `t.Run` → `t.Errorf(...)` directly
+- **Test mocks for routing logic**: When adding routing logic based on registry lookups (e.g., `UpdateHelper` checking `config_entry_id`), ALL existing tests hitting that code path need registry mocks added
+- **Wait mock pattern (entityDeleted flag)**: Specialized mocks (mockScriptClient, mockSceneClient, mockAutomationClient) track `entityDeleted bool`. Set `true` in successful Delete calls → `GetState` returns error immediately → `waitForEntityDisappear` resolves in one poll. For script mocks: only return entity for `strings.HasPrefix(entityID, "script.")` — prevents `snapshotEntities` in `call_service` from capturing unrelated entities causing 5s `waitForStateChanges` timeouts
+- **`runHandlerTestCases` fast WaitConfig**: Injects 50ms/5ms WaitConfig automatically via `mcp.WithWaitConfig`. Specialized mocks using `context.Background()` directly need `entityDeleted` tracking manually. Use `mcp.WithWaitConfig(ctx, cfg)` to inject short timeouts in tests calling handler functions directly
+
+### Integration Test Rules
+
+Integration tests in `internal/handlers/integration/` verify both write and read operations against a real Home Assistant instance.
+
+**Running integration tests:**
+```bash
+export HA_INTEGRATION_TEST_URL=http://homeassistant.local:8123
+export HA_INTEGRATION_TEST_TOKEN=<your-token>
+go test -tags=integration -v ./internal/handlers/integration/...
+set -a && source .env.integration && set +a && go test -tags=integration -v ./internal/handlers/integration/...
+```
+
+**Safety:** All test entities use `mcptest_<uuid>_<name>` prefix. Tests are skipped if environment variables are not set.
+
+**4-pattern for registry CRUD**: Each registry type (labels, floors, tags, areas) needs 4 tests (lifecycle, all fields, partial update, multiple items), 3 cleanup functions (cleanupTestX, deleteXWithRetry, CountTestX), FindXByID suite helper, and TearDownSuite verification block
+
+**Integration test scope**: Integration tests call client methods directly, bypassing handler logic. Handler-level features (config merging for partial updates, ID normalization) are tested via unit tests.
+
+**Tool coverage requirement**: Every MCP tool must have integration test coverage. For tools with write operations (CRUD), tests must verify full lifecycle. Tests may skip gracefully when:
+- Required entities don't exist (e.g., no cameras for camera tests)
+- Features are unavailable (e.g., read-only calendars, no release notes)
+- External dependencies missing (e.g., HACS not installed)
+
+**Test organization**: Group related tools in same file when appropriate (e.g., `updates_blueprints_integration_test.go` combines lightweight read-only tools).
+
+**Writable calendar detection pattern**: Some calendars (holiday calendars) are read-only. Integration tests must iterate calendars to find writable ones by testing GetCalendarEvents first.
+
+**Source entity wrapper pattern**: Config Entry helpers with domain requirements need template wrappers in tests: `createSourceSensor()` (input_number + template sensor), `createSourceSwitch()` (input_boolean + template switch with turn_on/turn_off service actions).
+
+**Pre-existing integration test failures on this HA instance** (not regression indicators): `TestZoneIntegration`, `TestPersonIntegration` → `unknown_command` (Zone/Person WS API unsupported on this HA version); `TestSwitchAsXIntegration` → `extra keys not allowed @ data['name']` (HA API validation tightened); `TestGenericThermostatIntegration`, `TestTemplateHelperIntegration/TestTemplateSensorUpdate` → HA version-specific 400 errors.
+
+## Workflow Preferences
+
+**Documentation Update Checklist**: When adding new tools, update all of the following:
+- `README.md` - tool count and summary table (Available Tools section)
+- `docs/tools.md` - full tool reference table and any new sections
+- `docs/architecture.md` - project structure file listing if adding handler files
+- `docs/feature-comparison.md` - tool count, feature comparison table
+- `CLAUDE.md` - Key Files section, Consolidated Tools section
+- `docs/integration-tests.md` - Test Categories table with new test suite operations
+- `.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md` - tool/action enum reference (if new tool or action added)
+- `.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md` - trap lookup (if new gotcha discovered)
+
+**Markdown Table Formatting**: All Markdown tables MUST be human-readable with properly aligned columns. Use consistent spacing and alignment to ensure tables are easy to read in their raw form, not just when rendered.
+
+**TDD Required**: Tests MUST be written BEFORE writing or modifying code. Run `golangci-lint run --timeout=5m ./...` after implementation.
+
+**File Editing Tool Priority**: Always use the dedicated file tools (Write, Edit) to create or modify files. Never use Bash with Python or shell commands to manipulate file content — the Write tool rewrites a complete file cleanly, the Edit tool makes surgical replacements. Python byte-level manipulation is error-prone, harder to read, and the wrong tool for the job.
+
+**CRLF Line Endings (Windows)**: `git config core.autocrlf=true` means working-directory files have CRLF line endings. The Edit tool silently fails to match multi-line strings in such files. When Edit fails unexpectedly on a file with many changes needed, use Write to rewrite the whole file instead of diagnosing the mismatch.
+
+### Extending Consolidated Tools (Modes/Actions)
+
+When adding new modes/actions to consolidated tools (`manage_*`, `query_entities`, `get_logbook`):
+1. Add constant (e.g., `automationActionCoverage = "coverage"`)
+2. Update action/mode switch with new case
+3. Update tool schema: Enum array, Description text
+4. Update error messages with full list of valid values
+5. Update test schema validation (expected enum count)
+6. Create dedicated file for complex logic (e.g., `*_coverage.go`, `*_presence.go`, `*_correlation.go`)
+7. If adding new tool (not just mode/action): Follow the Documentation Update Checklist above (README.md summary table, docs/tools.md full reference, docs/architecture.md structure, feature-comparison.md, CLAUDE.md, docs/integration-tests.md)
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **ha-mcp** (10603 symbols, 27107 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/ha-mcp/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/ha-mcp/clusters` | All functional areas |
+| `gitnexus://repo/ha-mcp/processes` | All execution flows |
+| `gitnexus://repo/ha-mcp/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->
+
+<!-- ha-mcp-skills:start -->
+# ha-mcp Skills
+
+For procedural guidance on using ha-mcp tools (decision trees, gotcha lookups, patch workflows), this project ships a skill bundle at `.claude/skills/ha-mcp/`. Use these when CLAUDE.md gives you the facts but you need the playbook.
+
+| Task                                     | Read this skill                                           |
+| ---------------------------------------- | --------------------------------------------------------- |
+| Pick the right tool / action             | `.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md`            |
+| Hit unexpected error or behavior         | `.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md`          |
+| Patch automation/script/scene/dashboard  | `.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md`         |
+| Reduce tokens / batch operations         | `.claude/skills/ha-mcp/ha-mcp-efficiency/SKILL.md`       |
+| Don't know where to start                | `.claude/skills/ha-mcp/ha-mcp-guide/SKILL.md`            |
+<!-- ha-mcp-skills:end -->

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zorak1103/ha-mcp
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/coder/websocket v1.8.14

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,13 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>v\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+GO_VERSION: \"(?<currentValue>\\S+)\""
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a bundle of 5 task-focused Claude Code skills under `.claude/skills/ha-mcp/` to help Claude work efficiently with the ha-mcp MCP server
- Tracks `CLAUDE.md` and `.claude/skills/gitnexus/` (previously gitignored)
- Updates `.gitignore` to ignore only `settings.json`/`settings.local.json` instead of the whole `.claude/` directory

## Skills

| Skill | Purpose |
| ----- | ------- |
| `ha-mcp-guide` | Entry-point index: always-do rules, sibling routing table, full tool cheat sheet |
| `ha-mcp-tools` | Intent→tool decision table + action enum reference for all 38 tools |
| `ha-mcp-gotchas` | 15-entry trap lookup: scene reload no-op, list-no-config, helper ID quirks, source entity wrappers, API field renames, etc. |
| `ha-mcp-patching` | RFC 6902 + semantic patch workflows with worked snippets |
| `ha-mcp-efficiency` | `format=natural`, `query_entities` batching, patch vs. update, Smart Wait, label/alias array modes |

## Test plan

- [ ] Verify skill files exist and have valid frontmatter (`name` matches folder, `description` starts with "Use when")
- [ ] Confirm `CLAUDE.md` contains the new `# ha-mcp Skills` section and updated Documentation Update Checklist
- [ ] Confirm `.claude/settings.json` is **not** tracked (`git ls-files .claude/settings.json` returns empty)
- [ ] Activate a skill in a fresh session: ask "Why does my scene not appear after create?" → `ha-mcp-gotchas` should load