### PR TITLE
feat: add manage_system_log tool for HA system log access (#86)

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
@@ -45,6 +45,8 @@ description: "Use when choosing which ha-mcp tool or action to call. Examples: \
 | Check for HA / add-on updates                        | `manage_update` action=list (pending_only=true)                        |
 | Manage todo list items                               | `manage_todo`                                                          |
 | Manage calendar events                               | `manage_calendar`                                                      |
+| Read HA error/warning logs                           | `manage_system_log` action=list                                        |
+| Clear the HA system log buffer                       | `manage_system_log` action=clear                                       |
 
 ## Consolidated Tool Action Reference
 
@@ -70,6 +72,7 @@ description: "Use when choosing which ha-mcp tool or action to call. Examples: \
 | `manage_update`       | list, release_notes                              | install, skip                                   |
 | `manage_todo`         | list, get_items                                  | add_item, update_item, remove_item              |
 | `manage_calendar`     | list, get_events                                 | create_event, delete_event                      |
+| `manage_system_log`   | list                                             | clear                                           |
 | `query_entities`      | current, history, statistics, domains, presence, health | (none)                                   |
 | `query_devices`       | health                                           | (none)                                          |
 | `analyze_target`      | all, triggers, conditions, services, entities    | (none)                                          |

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Auto-fix Go formatting on staged .go files so CI never sees unformatted code.
+set -e
+
+staged=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+gofmt -w $staged
+git add $staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Tool actions and parameters are defined in the handler schemas. Non-obvious aspe
 - `manage_automation` create: optional `automation_id` (bare slug e.g. `warme_buro`) overrides the auto-generated ID — needed when alias contains non-ASCII chars (umlauts) that HA's slugifier strips
 - `manage_helper` — 26 types. **WebSocket helpers** (input_*, counter, timer, schedule): `id` controls entity_id via create-then-update; **Config Entry helpers** (threshold, derivative, integral, group, template_*, utility_meter, min_max, statistics, trend, random_*, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat): `name` controls entity_id. Multi-step flows: statistics=3, filter=2, trend settings excludes name
 - `manage_hacs` — actions: list, info, get, releases, release_notes, critical, download, uninstall, add_repository, remove_repository, refresh, toggle_beta. All list filters (search, category, installed_only, pending_update) are client-side
+- `manage_system_log` — actions: list, clear. Uses `system_log/list` WS command (bounded to ~50 entries, no HA-side filter params — all filtering is client-side post-fetch). `clear` uses `system_log/clear`. No caching (logs are volatile). Handler: `internal/handlers/system_log.go`
 - All `manage_*` CRUD tools support Smart Wait (post-mutation polling, see below)
 
 **Label/Alias Array Mode (manage_entity, manage_device, manage_area, manage_floor):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ task lint:integration       # golangci-lint run --timeout=5m --build-tags=integr
 task fmt                    # gofmt -l . (check)
 task fmt:fix                # gofmt -w . (auto-fix)
 
+# Git hooks (run once after cloning)
+task install-hooks          # git config core.hooksPath .githooks (pre-commit: auto-fix gofmt)
+
 # Security & analysis
 task vulncheck              # govulncheck ./...
 task deadcode               # deadcode -test ./...  (install: go install golang.org/x/tools/cmd/deadcode@latest)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server that provides AI assistants with access to
 
 ## Features
 
-- **38 Specialized Tools**: Entity queries, automation CRUD, helper management, scripts, scenes, devices, areas, labels, floors, zones, persons, tags, traces, blueprints, updates, todos, calendars, cameras, dashboards, and more
+- **39 Specialized Tools**: Entity queries, automation CRUD, helper management, scripts, scenes, devices, areas, labels, floors, zones, persons, tags, traces, blueprints, updates, todos, calendars, cameras, dashboards, system log, and more
 - **Hybrid Architecture**: WebSocket for most operations, REST API for automation/script/scene CRUD
 - **Complete CRUD**: Create, read, update, delete automations/scripts/scenes/helpers
 - **Deep System Access**: Query registries, analyze dependencies, access logbook, validate config
@@ -33,7 +33,7 @@ Choose ha-mcp if you need:
 - Advanced analysis (dependencies, cross-references, automation coverage)
 - System administration (registry queries, config validation, logbook, history)
 - Media management (browser, camera streams), HACS, and dashboard access
-- Reliable LLM tool selection — 38 consolidated tools reduce selection errors compared to 95+ fine-grained alternatives
+- Reliable LLM tool selection — 39 consolidated tools reduce selection errors compared to 95+ fine-grained alternatives
 
 Choose the official integration if you need entity-level security or no external infrastructure.
 
@@ -126,7 +126,7 @@ See [docs/configuration.md](docs/configuration.md) for Cline, opencode, and othe
 
 ## Available Tools
 
-38 tools organized by domain. Full reference at [docs/tools.md](docs/tools.md).
+39 tools organized by domain. Full reference at [docs/tools.md](docs/tools.md).
 
 | Category          | Count | Highlights                                                                  |
 | ----------------- | ----- | --------------------------------------------------------------------------- |
@@ -141,6 +141,7 @@ See [docs/configuration.md](docs/configuration.md) for Cline, opencode, and othe
 | Dashboards/Media  | 4     | `manage_dashboard` (JSON Patch + semantic patch), `browse_media`, `manage_camera`, `sign_media_path` |
 | Calendars & Todos | 2     | `manage_calendar`, `manage_todo`                                            |
 | System/Admin      | 7     | `get_system_info`, `validate_config`, `manage_update`, `manage_blueprint`   |
+| Logs              | 1     | `manage_system_log` (list WARN/ERROR entries, clear ring buffer)            |
 | HACS              | 1     | `manage_hacs` (list, download, install, custom repos)                       |
 
 ## Access Control

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Requires Go 1.26 or later.
 ```bash
 git clone https://github.com/zorak1103/ha-mcp.git
 cd ha-mcp
+task install-hooks  # install git pre-commit hook (auto-fixes gofmt on every commit)
 go build -o ha-mcp ./cmd/ha-mcp
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,3 +95,13 @@ tasks:
     desc: Build a local snapshot release (does not publish)
     cmds:
       - goreleaser release --snapshot --clean --skip=publish
+
+  # ──────────────────────────────────────────────
+  # Setup
+  # ──────────────────────────────────────────────
+  install-hooks:
+    desc: Install git hooks (run once after cloning)
+    cmds:
+      - git config core.hooksPath .githooks
+      - chmod +x .githooks/pre-commit || true
+      - echo "Git hooks installed. Pre-commit hook auto-fixes gofmt on every commit."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,7 @@ ha-mcp/
 │   │   ├── templates.go         # Template rendering handler
 │   │   ├── logbook.go           # Logbook access handler (entries/correlation modes)
 │   │   ├── logbook_correlation.go # Logbook correlation analysis
+│   │   ├── system_log.go        # System log handler (manage_system_log: list/clear)
 │   │   ├── config.go            # Configuration validation handler
 │   │   ├── hacs.go              # HACS (Community Store) management handler
 │   │   ├── traces.go            # Trace viewing handler (automation/script execution traces)

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -8,7 +8,7 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 
 | Project | Description |
 | ------- | ----------- |
-| **ha-mcp** (this project) | Go binary, 38 specialized tools, HTTP JSON-RPC transport |
+| **ha-mcp** (this project) | Go binary, 39 specialized tools, HTTP JSON-RPC transport |
 | **Community ha-mcp** ([homeassistant-ai/ha-mcp](https://github.com/homeassistant-ai/ha-mcp)) | Python/FastMCP package, 95+ tools, stdio/SSE/HTTP/WebSocket transport |
 | **Official HA MCP Server** (built-in integration) | HA integration, ~10 intent-based tools, Streamable HTTP |
 
@@ -21,7 +21,7 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 | **Type**             | Standalone Go binary (external server)     | Python package (pip/uvx/Docker/Add-on)                       | HA integration (built-in)                                   |
 | **Transport**        | HTTP JSON-RPC                              | stdio, SSE, HTTP, WebSocket                                  | Streamable HTTP                                             |
 | **HA Communication** | WebSocket + REST API (Hybrid)              | WebSocket + REST API                                         | Direct Python API (internal)                                |
-| **Tool Design**      | 38 specialized tools with granular control | 95+ specialized tools                                        | Dynamically generated tools from Assist API (~10 tools)     |
+| **Tool Design**      | 39 specialized tools with granular control | 95+ specialized tools                                        | Dynamically generated tools from Assist API (~10 tools)     |
 | **Authentication**   | Long-Lived Access Token                    | Long-Lived Token + OAuth (beta)                              | OAuth (IndieAuth) + Long-Lived Token                        |
 | **Access Control**   | Tool-level filtering (read-only, whitelist/blacklist, action-level) | Entity/Service allow/deny lists with wildcard patterns | Entity-level exposure (Voice Assistant Exposure) |
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -108,7 +108,8 @@ go test -tags=integration -v ./internal/handlers/integration/... 2>&1 | tee test
 | `TestCalendarIntegration` | list, get_events, create_event (datetime + all-day), delete_event (with writable calendar detection) |
 | `TestTraceIntegration` | list automation traces, list script traces (execution history) |
 | `TestUpdateBlueprintIntegration` | list updates (pending filter), release_notes, list blueprints (automation/script) |
-| `TestCameraIntegration` | list cameras, stream (HLS URL via manage_camera), get_snapshot (binary image data) |
+| `TestCameraIntegration`    | list cameras, stream (HLS URL via manage_camera), get_snapshot (binary image data)                  |
+| `TestSystemLogIntegration` | GetSystemLog (list), ClearSystemLog (clear + verify empty)                                           |
 
 **Note:** Read-only tests (traces, updates, blueprints, cameras) verify API integration and response parsing. They skip gracefully if no entities exist or features are unavailable.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -256,6 +256,19 @@ Universal tool for runtime helper operations:
 | ---------------- | ------------------------------------------------------------------------------------------------ |
 | `manage_camera`  | Access camera snapshots and streams (actions: snapshot returns image, stream returns URL)        |
 
+### System Log Tools
+
+| Tool                 | Description                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manage_system_log`  | Read or clear the Home Assistant system log ring buffer (actions: list, clear). Supports level/integration/limit/include_exception/format filters. Uses `system_log/list` WebSocket command. |
+
+**Actions:**
+
+| Action  | Access | Description                                          | Key params                                              |
+| ------- | ------ | ---------------------------------------------------- | ------------------------------------------------------- |
+| `list`  | read   | Fetch recent WARNING/ERROR entries (~50 max by default) | `level`, `integration`, `limit`, `include_exception`, `format` |
+| `clear` | write  | Empty the in-memory ring buffer                      | —                                                       |
+
 ## Output Formats
 
 Most tools support two output formats via the `format` parameter:

--- a/internal/handlers/integration/system_log_integration_test.go
+++ b/internal/handlers/integration/system_log_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SystemLogIntegrationTestSuite struct {
+	HelperTestSuite
+}
+
+func TestSystemLogIntegration(t *testing.T) {
+	suite.Run(t, new(SystemLogIntegrationTestSuite))
+}
+
+func (s *SystemLogIntegrationTestSuite) TestGetSystemLog() {
+	ctx := context.Background()
+	entries, err := s.Client().GetSystemLog(ctx)
+	s.Require().NoError(err, "GetSystemLog should not return an error")
+
+	// Entries may be empty on a quiet HA instance, but the call must succeed.
+	for _, e := range entries {
+		s.NotEmpty(e.Name, "each entry should have a non-empty Name")
+		s.NotEmpty(e.Level, "each entry should have a non-empty Level")
+		s.NotEmpty(e.Message, "each entry should have a non-empty Message slice")
+		s.Greater(e.Timestamp, float64(0), "each entry should have a positive Timestamp")
+	}
+}
+
+func (s *SystemLogIntegrationTestSuite) TestClearSystemLog() {
+	ctx := context.Background()
+
+	// Clear the log buffer.
+	err := s.Client().ClearSystemLog(ctx)
+	s.Require().NoError(err, "ClearSystemLog should not return an error")
+
+	// After clearing, list should be empty (or at least not fail).
+	entries, err := s.Client().GetSystemLog(ctx)
+	s.Require().NoError(err, "GetSystemLog after clear should not error")
+	s.Empty(entries, "system log should be empty immediately after clear")
+}

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -66,6 +66,12 @@ func RegisterLogbookTools(registry *mcp.Registry) {
 	h.RegisterTools(registry)
 }
 
+// RegisterSystemLogTools registers the system log management tool with the registry.
+func RegisterSystemLogTools(registry *mcp.Registry) {
+	h := NewSystemLogHandlers()
+	h.RegisterTools(registry)
+}
+
 // RegisterConfigTools registers all configuration validation tools with the registry.
 func RegisterConfigTools(registry *mcp.Registry) {
 	h := NewConfigHandlers()
@@ -197,9 +203,10 @@ func RegisterAllTools(registry *mcp.Registry) {
 	RegisterSystemTools(registry)
 	RegisterDatetimeTools(registry)
 
-	// Template, logbook, and configuration tools
+	// Template, logbook, system log, and configuration tools
 	RegisterTemplateTools(registry)
 	RegisterLogbookTools(registry)
+	RegisterSystemLogTools(registry)
 	RegisterConfigTools(registry)
 
 	// Config entry tools (for accessing full config including template definitions)

--- a/internal/handlers/system_log.go
+++ b/internal/handlers/system_log.go
@@ -1,0 +1,227 @@
+// Package handlers provides MCP tool handlers for Home Assistant operations.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/mcp"
+)
+
+const (
+	systemLogActionList  = "list"
+	systemLogActionClear = "clear"
+)
+
+// SystemLogHandlers provides handlers for Home Assistant system log operations.
+type SystemLogHandlers struct{}
+
+// NewSystemLogHandlers creates a new SystemLogHandlers instance.
+func NewSystemLogHandlers() *SystemLogHandlers {
+	return &SystemLogHandlers{}
+}
+
+// RegisterTools registers all system-log-related tools with the registry.
+func (h *SystemLogHandlers) RegisterTools(registry *mcp.Registry) {
+	registry.RegisterTool(h.manageSystemLogTool(), h.handleManageSystemLog)
+}
+
+// manageSystemLogTool returns the tool definition for system log management.
+func (h *SystemLogHandlers) manageSystemLogTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        "manage_system_log",
+		Description: "Read or clear the Home Assistant system log. Use action=list to fetch recent WARNING/ERROR log entries (ideal for investigating errors), action=clear to reset the ring buffer.",
+		InputSchema: mcp.JSONSchema{
+			Type: "object",
+			Properties: map[string]mcp.JSONSchema{
+				"action": {
+					Type:        "string",
+					Enum:        []string{systemLogActionList, systemLogActionClear},
+					Description: "Action to perform: 'list' to retrieve log entries, 'clear' to empty the ring buffer",
+				},
+				"level": {
+					Type:        "string",
+					Enum:        []string{"warning", "error", "critical"},
+					Description: "Filter by severity level (case-insensitive). Default: all levels",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Maximum number of entries to return. Default: 50 (the HA ring buffer size)",
+				},
+				"integration": {
+					Type:        "string",
+					Description: "Filter entries by integration name (case-insensitive substring match on 'name' field, e.g. 'mqtt', 'zwave_js')",
+				},
+				"include_exception": {
+					Type:        "boolean",
+					Description: "Include exception stack traces in the output. Default: true. Set to false to reduce token usage.",
+				},
+				"format": {
+					Type:        "string",
+					Enum:        []string{formatNatural, formatJSON},
+					Description: "Output format: 'natural' for readable text (default), 'json' for structured JSON",
+				},
+			},
+			Required: []string{"action"},
+		},
+	}
+}
+
+// handleManageSystemLog dispatches to the appropriate action handler.
+func (h *SystemLogHandlers) handleManageSystemLog(
+	ctx context.Context,
+	client homeassistant.Client,
+	args map[string]any,
+) (*mcp.ToolsCallResult, error) {
+	action := getString(args, "action")
+	switch action {
+	case systemLogActionList:
+		return h.handleSystemLogList(ctx, client, args)
+	case systemLogActionClear:
+		return h.handleSystemLogClear(ctx, client)
+	default:
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{
+				mcp.NewTextContent(fmt.Sprintf("invalid action %q: must be one of [list, clear]", action)),
+			},
+			IsError: true,
+		}, nil
+	}
+}
+
+// handleSystemLogList fetches and formats system log entries.
+func (h *SystemLogHandlers) handleSystemLogList(
+	ctx context.Context,
+	client homeassistant.Client,
+	args map[string]any,
+) (*mcp.ToolsCallResult, error) {
+	entries, err := client.GetSystemLog(ctx)
+	if err != nil {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("error fetching system log: %v", err))},
+			IsError: true,
+		}, nil
+	}
+
+	entries = filterSystemLogEntries(entries, args)
+
+	includeException := true
+	if v, ok := args["include_exception"].(bool); ok {
+		includeException = v
+	}
+
+	format := getString(args, "format")
+	var output string
+	if format == formatJSON {
+		output, err = formatSystemLogJSON(entries, includeException)
+	} else {
+		output = formatSystemLogNatural(entries, includeException)
+	}
+	if err != nil {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("error formatting output: %v", err))},
+			IsError: true,
+		}, nil
+	}
+
+	return &mcp.ToolsCallResult{
+		Content: []mcp.ContentBlock{mcp.NewTextContent(output)},
+	}, nil
+}
+
+// handleSystemLogClear clears the system log ring buffer.
+func (h *SystemLogHandlers) handleSystemLogClear(ctx context.Context, client homeassistant.Client) (*mcp.ToolsCallResult, error) {
+	if err := client.ClearSystemLog(ctx); err != nil {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("error clearing system log: %v", err))},
+			IsError: true,
+		}, nil
+	}
+	return &mcp.ToolsCallResult{
+		Content: []mcp.ContentBlock{mcp.NewTextContent("System log cleared successfully.")},
+	}, nil
+}
+
+// filterSystemLogEntries applies level, integration, and limit filters.
+func filterSystemLogEntries(entries []homeassistant.SystemLogEntry, args map[string]any) []homeassistant.SystemLogEntry {
+	level := strings.ToLower(getString(args, "level"))
+	integration := strings.ToLower(getString(args, "integration"))
+	limitVal := getInt(args, "limit")
+
+	var filtered []homeassistant.SystemLogEntry
+	for _, e := range entries {
+		if level != "" && !strings.EqualFold(e.Level, level) {
+			continue
+		}
+		if integration != "" && !strings.Contains(strings.ToLower(e.Name), integration) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+
+	if limitVal > 0 && len(filtered) > limitVal {
+		filtered = filtered[:limitVal]
+	}
+	return filtered
+}
+
+// formatSystemLogNatural produces a human-readable log summary.
+func formatSystemLogNatural(entries []homeassistant.SystemLogEntry, includeException bool) string {
+	if len(entries) == 0 {
+		return "No system log entries found matching the given filters."
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Found %d system log %s\n", len(entries), pluralize(len(entries), "entry", "entries"))
+
+	for _, e := range entries {
+		msg := strings.Join(e.Message, " ")
+		firstTime := unixToUTC(e.FirstOccurred)
+		fmt.Fprintf(&sb, "\n[%s] %s (%dx, first: %s)\n", strings.ToUpper(e.Level), e.Name, e.Count, firstTime)
+		if len(e.Source) >= 2 {
+			fmt.Fprintf(&sb, "  Source: %v:%v\n", e.Source[0], e.Source[1])
+		}
+		fmt.Fprintf(&sb, "  Message: %s\n", msg)
+		if includeException && e.Exception != "" {
+			fmt.Fprintf(&sb, "  Exception:\n    %s\n", strings.ReplaceAll(e.Exception, "\n", "\n    "))
+		}
+	}
+	return sb.String()
+}
+
+// formatSystemLogJSON serializes the entries as indented JSON.
+func formatSystemLogJSON(entries []homeassistant.SystemLogEntry, includeException bool) (string, error) {
+	if !includeException {
+		stripped := make([]homeassistant.SystemLogEntry, len(entries))
+		copy(stripped, entries)
+		for i := range stripped {
+			stripped[i].Exception = ""
+		}
+		entries = stripped
+	}
+	b, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// pluralize returns singular or plural form based on count.
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// unixToUTC converts a Unix float64 timestamp to a UTC time string.
+func unixToUTC(ts float64) string {
+	sec := int64(ts)
+	nsec := int64((ts - math.Trunc(ts)) * 1e9)
+	return time.Unix(sec, nsec).UTC().Format("2006-01-02 15:04:05 UTC")
+}

--- a/internal/handlers/system_log_test.go
+++ b/internal/handlers/system_log_test.go
@@ -1,0 +1,255 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/mcp"
+)
+
+func TestSystemLogHandlers_RegisterTools(t *testing.T) {
+	t.Parallel()
+
+	h := NewSystemLogHandlers()
+	registry := mcp.NewRegistry()
+	h.RegisterTools(registry)
+
+	tools := registry.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("RegisterTools() registered %d tools, want 1", len(tools))
+	}
+	if tools[0].Name != "manage_system_log" {
+		t.Errorf("tool name = %q, want manage_system_log", tools[0].Name)
+	}
+}
+
+func TestSystemLogHandlers_Schema(t *testing.T) {
+	t.Parallel()
+
+	h := NewSystemLogHandlers()
+	tool := h.manageSystemLogTool()
+
+	verifyToolSchema(t, tool, toolSchemaExpectation{
+		ExpectedName:    "manage_system_log",
+		RequiredParams:  []string{"action"},
+		OptionalParams:  []string{"level", "limit", "integration", "include_exception", "format"},
+		WantDescription: true,
+	})
+}
+
+func TestSystemLogHandlers_HandleManageSystemLog(t *testing.T) {
+	t.Parallel()
+
+	mqttEntry := homeassistant.SystemLogEntry{
+		Name:          "homeassistant.components.mqtt",
+		Message:       []string{"Connection lost"},
+		Level:         "WARNING",
+		Source:        []any{"components/mqtt/client.py", float64(123)},
+		Timestamp:     1705312800.0,
+		Exception:     "",
+		Count:         2,
+		FirstOccurred: 1705312800.0,
+	}
+	coreErrorEntry := homeassistant.SystemLogEntry{
+		Name:          "homeassistant.core",
+		Message:       []string{"Something went wrong"},
+		Level:         "ERROR",
+		Source:        []any{"homeassistant/core.py", float64(456)},
+		Timestamp:     1705312900.0,
+		Exception:     "Traceback (most recent call last):\n  File 'core.py', line 456, in run\nValueError: bad value",
+		Count:         1,
+		FirstOccurred: 1705312900.0,
+	}
+	zwaveEntry := homeassistant.SystemLogEntry{
+		Name:          "homeassistant.components.zwave_js",
+		Message:       []string{"Node unavailable"},
+		Level:         "WARNING",
+		Source:        []any{"components/zwave_js/node.py", float64(789)},
+		Timestamp:     1705312850.0,
+		Exception:     "",
+		Count:         3,
+		FirstOccurred: 1705312850.0,
+	}
+
+	h := NewSystemLogHandlers()
+
+	tests := []handlerTestCase{
+		{
+			name: "list happy path - all entries returned",
+			args: map[string]any{"action": "list"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry, coreErrorEntry, zwaveEntry}, nil
+				}
+			},
+			wantError:    false,
+			wantContains: []string{"Found 3 system log", "homeassistant.components.mqtt", "homeassistant.core", "homeassistant.components.zwave_js"},
+		},
+		{
+			name: "list with level=error filter",
+			args: map[string]any{"action": "list", "level": "error"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry, coreErrorEntry, zwaveEntry}, nil
+				}
+			},
+			wantError:       false,
+			wantContains:    []string{"homeassistant.core", "ERROR"},
+			wantNotContains: []string{"homeassistant.components.mqtt", "homeassistant.components.zwave_js"},
+		},
+		{
+			name: "list with integration substring filter",
+			args: map[string]any{"action": "list", "integration": "mqtt"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry, coreErrorEntry, zwaveEntry}, nil
+				}
+			},
+			wantError:       false,
+			wantContains:    []string{"homeassistant.components.mqtt"},
+			wantNotContains: []string{"homeassistant.core", "homeassistant.components.zwave_js"},
+		},
+		{
+			name: "list with include_exception=false strips stack traces",
+			args: map[string]any{"action": "list", "include_exception": false},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{coreErrorEntry}, nil
+				}
+			},
+			wantError:       false,
+			wantContains:    []string{"homeassistant.core"},
+			wantNotContains: []string{"Traceback", "ValueError"},
+		},
+		{
+			name: "list with limit=1 truncates results",
+			args: map[string]any{"action": "list", "limit": float64(1)},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry, coreErrorEntry, zwaveEntry}, nil
+				}
+			},
+			wantError:       false,
+			wantContains:    []string{"Found 1 system log entry", "homeassistant.components.mqtt"},
+			wantNotContains: []string{"homeassistant.core", "homeassistant.components.zwave_js"},
+		},
+		{
+			name: "list with format=json returns valid JSON",
+			args: map[string]any{"action": "list", "format": "json"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry}, nil
+				}
+			},
+			wantError:    false,
+			wantContains: []string{"homeassistant.components.mqtt", "WARNING"},
+		},
+		{
+			name: "list empty result",
+			args: map[string]any{"action": "list", "level": "critical"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return []homeassistant.SystemLogEntry{mqttEntry, coreErrorEntry}, nil
+				}
+			},
+			wantError:    false,
+			wantContains: []string{"No system log entries"},
+		},
+		{
+			name: "list propagates client error",
+			args: map[string]any{"action": "list"},
+			setupMock: func(m *UniversalMockClient) {
+				m.GetSystemLogFn = func(_ context.Context) ([]homeassistant.SystemLogEntry, error) {
+					return nil, errors.New("connection failed")
+				}
+			},
+			wantError:    true,
+			wantContains: []string{"connection failed"},
+		},
+		{
+			name: "clear happy path",
+			args: map[string]any{"action": "clear"},
+			setupMock: func(m *UniversalMockClient) {
+				m.ClearSystemLogFn = func(_ context.Context) error { return nil }
+			},
+			wantError:    false,
+			wantContains: []string{"System log cleared"},
+		},
+		{
+			name: "clear propagates error",
+			args: map[string]any{"action": "clear"},
+			setupMock: func(m *UniversalMockClient) {
+				m.ClearSystemLogFn = func(_ context.Context) error { return errors.New("ws disconnected") }
+			},
+			wantError:    true,
+			wantContains: []string{"ws disconnected"},
+		},
+		{
+			name:         "invalid action",
+			args:         map[string]any{"action": "delete"},
+			wantError:    true,
+			wantContains: []string{"invalid action", "delete"},
+		},
+		{
+			name:         "missing action",
+			args:         map[string]any{},
+			wantError:    true,
+			wantContains: []string{"invalid action"},
+		},
+	}
+
+	runHandlerTestCases(t, tests, h.handleManageSystemLog)
+}
+
+func TestSystemLogHandlers_JSONFormatValid(t *testing.T) {
+	t.Parallel()
+
+	entry := homeassistant.SystemLogEntry{
+		Name:    "homeassistant.core",
+		Message: []string{"error msg"},
+		Level:   "ERROR",
+	}
+
+	output, err := formatSystemLogJSON([]homeassistant.SystemLogEntry{entry}, true)
+	if err != nil {
+		t.Fatalf("formatSystemLogJSON() error = %v", err)
+	}
+
+	var parsed []homeassistant.SystemLogEntry
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("JSON output is not valid JSON: %v\nGot: %s", err, output)
+	}
+	if len(parsed) != 1 {
+		t.Errorf("parsed %d entries, want 1", len(parsed))
+	}
+	if parsed[0].Name != "homeassistant.core" {
+		t.Errorf("entry name = %q, want homeassistant.core", parsed[0].Name)
+	}
+}
+
+func TestSystemLogHandlers_JSONFormatStripsException(t *testing.T) {
+	t.Parallel()
+
+	entry := homeassistant.SystemLogEntry{
+		Name:      "homeassistant.core",
+		Message:   []string{"err"},
+		Level:     "ERROR",
+		Exception: "Traceback...",
+	}
+
+	output, err := formatSystemLogJSON([]homeassistant.SystemLogEntry{entry}, false)
+	if err != nil {
+		t.Fatalf("formatSystemLogJSON() error = %v", err)
+	}
+
+	var parsed []homeassistant.SystemLogEntry
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("JSON output is not valid JSON: %v", err)
+	}
+	if parsed[0].Exception != "" {
+		t.Errorf("exception not stripped; got %q", parsed[0].Exception)
+	}
+}

--- a/internal/handlers/testing_helpers_test.go
+++ b/internal/handlers/testing_helpers_test.go
@@ -140,7 +140,7 @@ type UniversalMockClient struct {
 	GetLogbookFn func(ctx context.Context, startTime, endTime, entityID string) ([]homeassistant.LogbookEntry, error)
 
 	// System log operations
-	GetSystemLogFn  func(ctx context.Context) ([]homeassistant.SystemLogEntry, error)
+	GetSystemLogFn   func(ctx context.Context) ([]homeassistant.SystemLogEntry, error)
 	ClearSystemLogFn func(ctx context.Context) error
 
 	// Configuration validation operations

--- a/internal/handlers/testing_helpers_test.go
+++ b/internal/handlers/testing_helpers_test.go
@@ -139,6 +139,10 @@ type UniversalMockClient struct {
 	// Logbook operations
 	GetLogbookFn func(ctx context.Context, startTime, endTime, entityID string) ([]homeassistant.LogbookEntry, error)
 
+	// System log operations
+	GetSystemLogFn  func(ctx context.Context) ([]homeassistant.SystemLogEntry, error)
+	ClearSystemLogFn func(ctx context.Context) error
+
 	// Configuration validation operations
 	CheckConfigFn func(ctx context.Context) (*homeassistant.ConfigCheckResult, error)
 
@@ -763,6 +767,22 @@ func (m *UniversalMockClient) GetLogbook(ctx context.Context, startTime, endTime
 		return m.GetLogbookFn(ctx, startTime, endTime, entityID)
 	}
 	return []homeassistant.LogbookEntry{}, nil
+}
+
+// System log operations implementation
+
+func (m *UniversalMockClient) GetSystemLog(ctx context.Context) ([]homeassistant.SystemLogEntry, error) {
+	if m.GetSystemLogFn != nil {
+		return m.GetSystemLogFn(ctx)
+	}
+	return []homeassistant.SystemLogEntry{}, nil
+}
+
+func (m *UniversalMockClient) ClearSystemLog(ctx context.Context) error {
+	if m.ClearSystemLogFn != nil {
+		return m.ClearSystemLogFn(ctx)
+	}
+	return nil
 }
 
 // Configuration validation operations implementation

--- a/internal/homeassistant/cached_client.go
+++ b/internal/homeassistant/cached_client.go
@@ -933,6 +933,16 @@ func (c *CachedClient) GetCameraSnapshot(ctx context.Context, entityID string) (
 }
 
 //nolint:revive // Delegated method
+func (c *CachedClient) GetSystemLog(ctx context.Context) ([]SystemLogEntry, error) {
+	return c.client.GetSystemLog(ctx)
+}
+
+//nolint:revive // Delegated method
+func (c *CachedClient) ClearSystemLog(ctx context.Context) error {
+	return c.client.ClearSystemLog(ctx)
+}
+
+//nolint:revive // Delegated method
 func (c *CachedClient) GetConfigEntries(ctx context.Context, domain string) ([]ConfigEntryFull, error) {
 	return c.client.GetConfigEntries(ctx, domain)
 }

--- a/internal/homeassistant/cached_client_test.go
+++ b/internal/homeassistant/cached_client_test.go
@@ -317,8 +317,8 @@ func (m *mockClient) RenderTemplate(ctx context.Context, template string) (strin
 func (m *mockClient) GetLogbook(ctx context.Context, startTime, endTime, entityID string) ([]LogbookEntry, error) {
 	return nil, nil
 }
-func (m *mockClient) GetSystemLog(context.Context) ([]SystemLogEntry, error) { return nil, nil }
-func (m *mockClient) ClearSystemLog(context.Context) error                   { return nil }
+func (m *mockClient) GetSystemLog(context.Context) ([]SystemLogEntry, error)      { return nil, nil }
+func (m *mockClient) ClearSystemLog(context.Context) error                        { return nil }
 func (m *mockClient) CheckConfig(ctx context.Context) (*ConfigCheckResult, error) { return nil, nil }
 func (m *mockClient) GetConfigEntries(ctx context.Context, domain string) ([]ConfigEntryFull, error) {
 	return nil, nil

--- a/internal/homeassistant/cached_client_test.go
+++ b/internal/homeassistant/cached_client_test.go
@@ -317,6 +317,8 @@ func (m *mockClient) RenderTemplate(ctx context.Context, template string) (strin
 func (m *mockClient) GetLogbook(ctx context.Context, startTime, endTime, entityID string) ([]LogbookEntry, error) {
 	return nil, nil
 }
+func (m *mockClient) GetSystemLog(context.Context) ([]SystemLogEntry, error) { return nil, nil }
+func (m *mockClient) ClearSystemLog(context.Context) error                   { return nil }
 func (m *mockClient) CheckConfig(ctx context.Context) (*ConfigCheckResult, error) { return nil, nil }
 func (m *mockClient) GetConfigEntries(ctx context.Context, domain string) ([]ConfigEntryFull, error) {
 	return nil, nil

--- a/internal/homeassistant/client.go
+++ b/internal/homeassistant/client.go
@@ -162,6 +162,10 @@ type Client interface {
 
 	// Camera operations
 	GetCameraSnapshot(ctx context.Context, entityID string) ([]byte, string, error)
+
+	// System log operations
+	GetSystemLog(ctx context.Context) ([]SystemLogEntry, error)
+	ClearSystemLog(ctx context.Context) error
 }
 
 // APIError represents an error response from the Home Assistant API.

--- a/internal/homeassistant/client_pool_test.go
+++ b/internal/homeassistant/client_pool_test.go
@@ -351,6 +351,8 @@ func (m *mockClientForPool) RenderTemplate(_ context.Context, _ string) (string,
 func (m *mockClientForPool) GetLogbook(_ context.Context, _, _, _ string) ([]LogbookEntry, error) {
 	return nil, nil
 }
+func (m *mockClientForPool) GetSystemLog(context.Context) ([]SystemLogEntry, error) { return nil, nil }
+func (m *mockClientForPool) ClearSystemLog(context.Context) error                   { return nil }
 func (m *mockClientForPool) CheckConfig(_ context.Context) (*ConfigCheckResult, error) {
 	return nil, nil
 }

--- a/internal/homeassistant/factory_test.go
+++ b/internal/homeassistant/factory_test.go
@@ -432,6 +432,11 @@ func (m *mockNonCloserClient) GetLogbook(_ context.Context, _, _, _ string) ([]L
 	return []LogbookEntry{}, nil
 }
 
+func (m *mockNonCloserClient) GetSystemLog(context.Context) ([]SystemLogEntry, error) {
+	return nil, nil
+}
+func (m *mockNonCloserClient) ClearSystemLog(context.Context) error { return nil }
+
 func (m *mockNonCloserClient) CheckConfig(_ context.Context) (*ConfigCheckResult, error) {
 	return &ConfigCheckResult{Result: "valid"}, nil
 }

--- a/internal/homeassistant/hybrid_client.go
+++ b/internal/homeassistant/hybrid_client.go
@@ -143,6 +143,10 @@ type WSOperations interface {
 	GetConfigEntries(ctx context.Context, domain string) ([]ConfigEntryFull, error)
 	GetConfigEntry(ctx context.Context, entryID string) (*ConfigEntryFull, error)
 	SendHACSCommand(ctx context.Context, command string, data map[string]any) (any, error)
+
+	// System log operations (WebSocket-native)
+	GetSystemLog(ctx context.Context) ([]SystemLogEntry, error)
+	ClearSystemLog(ctx context.Context) error
 }
 
 // RESTOperations is an interface for REST client operations.
@@ -1386,6 +1390,20 @@ func (c *HybridClient) GetCameraSnapshot(ctx context.Context, entityID string) (
 // SendHACSCommand sends a generic HACS WebSocket command.
 func (c *HybridClient) SendHACSCommand(ctx context.Context, command string, data map[string]any) (any, error) {
 	return c.ws.SendHACSCommand(ctx, command, data)
+}
+
+// =============================================================================
+// System Log Operations (delegated to WebSocket)
+// =============================================================================
+
+// GetSystemLog retrieves system log entries from the Home Assistant ring buffer.
+func (c *HybridClient) GetSystemLog(ctx context.Context) ([]SystemLogEntry, error) {
+	return c.ws.GetSystemLog(ctx)
+}
+
+// ClearSystemLog clears the Home Assistant system log ring buffer.
+func (c *HybridClient) ClearSystemLog(ctx context.Context) error {
+	return c.ws.ClearSystemLog(ctx)
 }
 
 // =============================================================================

--- a/internal/homeassistant/hybrid_client_test.go
+++ b/internal/homeassistant/hybrid_client_test.go
@@ -490,6 +490,8 @@ type mockWSOperations struct {
 	getConfigEntriesFunc        func(ctx context.Context, domain string) ([]ConfigEntryFull, error)
 	getConfigEntryFunc          func(ctx context.Context, entryID string) (*ConfigEntryFull, error)
 	sendHACSCommandFunc         func(ctx context.Context, command string, data map[string]any) (any, error)
+	getSystemLogFunc            func(ctx context.Context) ([]SystemLogEntry, error)
+	clearSystemLogFunc          func(ctx context.Context) error
 }
 
 func (m *mockWSOperations) GetStates(ctx context.Context) ([]Entity, error) {
@@ -975,6 +977,20 @@ func (m *mockWSOperations) SendHACSCommand(ctx context.Context, command string, 
 		return m.sendHACSCommandFunc(ctx, command, data)
 	}
 	return nil, nil
+}
+
+func (m *mockWSOperations) GetSystemLog(ctx context.Context) ([]SystemLogEntry, error) {
+	if m.getSystemLogFunc != nil {
+		return m.getSystemLogFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockWSOperations) ClearSystemLog(ctx context.Context) error {
+	if m.clearSystemLogFunc != nil {
+		return m.clearSystemLogFunc(ctx)
+	}
+	return nil
 }
 
 // mockRESTOperations implements RESTOperations for testing.

--- a/internal/homeassistant/rest_client.go
+++ b/internal/homeassistant/rest_client.go
@@ -1336,3 +1336,13 @@ func (c *RESTClient) GetCameraSnapshot(ctx context.Context, entityID string) ([]
 
 	return imageData, contentType, nil
 }
+
+// GetSystemLog is not supported via REST API.
+func (c *RESTClient) GetSystemLog(_ context.Context) ([]SystemLogEntry, error) {
+	return nil, fmt.Errorf("GetSystemLog not supported via REST API, use WebSocket or HybridClient")
+}
+
+// ClearSystemLog is not supported via REST API.
+func (c *RESTClient) ClearSystemLog(_ context.Context) error {
+	return fmt.Errorf("ClearSystemLog not supported via REST API, use WebSocket or HybridClient")
+}

--- a/internal/homeassistant/types.go
+++ b/internal/homeassistant/types.go
@@ -610,14 +610,14 @@ type LogbookEntry struct {
 
 // SystemLogEntry represents a single entry in the Home Assistant system log ring buffer.
 type SystemLogEntry struct {
-	Name          string  `json:"name"`
+	Name          string   `json:"name"`
 	Message       []string `json:"message"`
-	Level         string  `json:"level"`
-	Source        []any   `json:"source"` // [filename, line_number] — heterogeneous tuple
-	Timestamp     float64 `json:"timestamp"`
-	Exception     string  `json:"exception"`
-	Count         int     `json:"count"`
-	FirstOccurred float64 `json:"first_occurred"`
+	Level         string   `json:"level"`
+	Source        []any    `json:"source"` // [filename, line_number] — heterogeneous tuple
+	Timestamp     float64  `json:"timestamp"`
+	Exception     string   `json:"exception"`
+	Count         int      `json:"count"`
+	FirstOccurred float64  `json:"first_occurred"`
 }
 
 // ConfigCheckResult represents the result of a configuration validation check.

--- a/internal/homeassistant/types.go
+++ b/internal/homeassistant/types.go
@@ -608,6 +608,18 @@ type LogbookEntry struct {
 	ContextUserID *string `json:"context_user_id,omitempty"`
 }
 
+// SystemLogEntry represents a single entry in the Home Assistant system log ring buffer.
+type SystemLogEntry struct {
+	Name          string  `json:"name"`
+	Message       []string `json:"message"`
+	Level         string  `json:"level"`
+	Source        []any   `json:"source"` // [filename, line_number] — heterogeneous tuple
+	Timestamp     float64 `json:"timestamp"`
+	Exception     string  `json:"exception"`
+	Count         int     `json:"count"`
+	FirstOccurred float64 `json:"first_occurred"`
+}
+
 // ConfigCheckResult represents the result of a configuration validation check.
 type ConfigCheckResult struct {
 	Result string  `json:"result"` // "valid" or "invalid"

--- a/internal/homeassistant/ws_client_impl.go
+++ b/internal/homeassistant/ws_client_impl.go
@@ -1854,6 +1854,34 @@ func (c *wsClientImpl) GetCalendars(_ context.Context) ([]CalendarEntry, error) 
 	return nil, fmt.Errorf("GetCalendars not supported via WebSocket API, use REST API or HybridClient")
 }
 
+// =============================================================================
+// System Log Operations (WebSocket-only)
+// =============================================================================
+
+// GetSystemLog retrieves the system log entries from the Home Assistant ring buffer.
+func (c *wsClientImpl) GetSystemLog(ctx context.Context) ([]SystemLogEntry, error) {
+	result, err := c.ws.SendCommand(ctx, "system_log/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("get system log failed: %w", err)
+	}
+
+	var entries []SystemLogEntry
+	if err := json.Unmarshal(result.Result, &entries); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal system log: %w", err)
+	}
+
+	return entries, nil
+}
+
+// ClearSystemLog clears the Home Assistant system log ring buffer.
+func (c *wsClientImpl) ClearSystemLog(ctx context.Context) error {
+	_, err := c.ws.SendCommand(ctx, "system_log/clear", nil)
+	if err != nil {
+		return fmt.Errorf("clear system log failed: %w", err)
+	}
+	return nil
+}
+
 // GetCalendarEvents retrieves calendar events.
 // Note: This operation is only available via REST API. Use HybridClient for full functionality.
 func (c *wsClientImpl) GetCalendarEvents(_ context.Context, _, _, _ string) ([]CalendarEvent, error) {

--- a/internal/mcp/access_control.go
+++ b/internal/mcp/access_control.go
@@ -208,6 +208,10 @@ func addSpecialManagementTools(result map[string]ToolClassification) {
 		ParamName: "action",
 		Actions:   map[string]ActionCategory{"snapshot": CategoryRead, "stream": CategoryRead},
 	}
+	result["manage_system_log"] = ToolClassification{
+		ParamName: "action",
+		Actions:   map[string]ActionCategory{"list": CategoryRead, "clear": CategoryWrite},
+	}
 }
 
 // buildQueryTools returns query and analysis tools with mode/type/info parameters.

--- a/internal/mcp/access_control_test.go
+++ b/internal/mcp/access_control_test.go
@@ -47,6 +47,7 @@ func TestAccessControlMapCompleteness(t *testing.T) {
 		"manage_todo",
 		"manage_calendar",
 		"manage_camera",
+		"manage_system_log",
 
 		// Media and rendering
 		"render_template",
@@ -221,6 +222,12 @@ func TestManagedToolsActions(t *testing.T) {
 			paramName:    "action",
 			readActions:  []string{"list", "get"},
 			writeActions: []string{},
+		},
+		{
+			tool:         "manage_system_log",
+			paramName:    "action",
+			readActions:  []string{"list"},
+			writeActions: []string{"clear"},
 		},
 	}
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -367,6 +367,12 @@ func (m *mockHAClient) SendHACSCommand(_ context.Context, _ string, _ map[string
 	return nil, nil
 }
 
+func (m *mockHAClient) GetSystemLog(context.Context) ([]homeassistant.SystemLogEntry, error) {
+	return nil, nil
+}
+
+func (m *mockHAClient) ClearSystemLog(context.Context) error { return nil }
+
 func TestNewServer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds `manage_system_log` MCP tool with two actions: `list` (read) and `clear` (write)
- `list` fetches the Home Assistant system log ring buffer via WebSocket `system_log/list` and applies client-side filters: `level` (warning/error/critical), `integration` (name substring), `limit`, `include_exception` (stack trace toggle), `format` (natural/json)
- `clear` empties the in-memory ring buffer via `system_log/clear`
- `clear` is automatically blocked by `--read-only` mode (access control classification in `access_control.go`)

## Why

Home Assistant no longer writes `home-assistant.log` by default, so users have to open the HA UI to investigate errors. This tool lets AI assistants answer prompts like *"investigate any errors or warnings and tell me how to fix them."*

## Implementation notes

- Uses the 12-file `Client` interface pattern: `GetSystemLog`/`ClearSystemLog` are WebSocket-native with REST stubs for interface compliance
- Filtering is client-side (HA's `system_log/list` accepts no params); bounded to ~50 entries (HA's default ring buffer size)
- No caching (logs are volatile by design)
- Handler: `internal/handlers/system_log.go` — follows the `templates.go` single-domain pattern
- Access control: `manage_system_log:list` → read, `manage_system_log:clear` → write

## Test plan

- [x] 17 unit tests in `internal/handlers/system_log_test.go` — all pass (happy path, each filter, format=json, error propagation, invalid action)
- [x] 2 integration tests in `internal/handlers/integration/system_log_integration_test.go` — cover `GetSystemLog` and `ClearSystemLog` against real HA
- [x] `TestAccessControlMapCompleteness` and `TestManagedToolsActions` updated and passing
- [x] Full test suite: 8/8 packages green (fresh run, no cache)
- [x] Build: `go build ./...` exits 0

Closes #86