### PR TITLE
feat: expose ha-mcp guidance as MCP skill:// resources (closes #92)

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
@@ -47,6 +47,7 @@ description: "Use when choosing which ha-mcp tool or action to call. Examples: \
 | Manage calendar events                               | `manage_calendar`                                                      |
 | Read HA error/warning logs                           | `manage_system_log` action=list                                        |
 | Clear the HA system log buffer                       | `manage_system_log` action=clear                                       |
+| Get ha-mcp guidance on a topic                       | `get_skill` action=list / action=read skill=<slug>                     |
 
 ## Consolidated Tool Action Reference
 
@@ -73,6 +74,7 @@ description: "Use when choosing which ha-mcp tool or action to call. Examples: \
 | `manage_todo`         | list, get_items                                  | add_item, update_item, remove_item              |
 | `manage_calendar`     | list, get_events                                 | create_event, delete_event                      |
 | `manage_system_log`   | list                                             | clear                                           |
+| `get_skill`           | list, read                                       | (none — read-only)                              |
 | `query_entities`      | current, history, statistics, domains, presence, health | (none)                                   |
 | `query_devices`       | health                                           | (none)                                          |
 | `analyze_target`      | all, triggers, conditions, services, entities    | (none)                                          |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ AI Client (Claude, Cline)
 - `entities_consolidated.go` → `query_entities`; `devices_consolidated.go` → `query_devices`
 - `targets_consolidated.go` → `analyze_target`; `registry_consolidated.go` → `get_registry`
 - `entities_manage.go` → `manage_entity`; `devices_manage.go` → `manage_device`
+- `skill.go` → `get_skill` tool + `RegisterAllResources` (wires 7 skill:// resources)
+- `skills/catalog.go` → embedded markdown catalog; add slug here + .md file when adding a skill
 
 Extended logic in dedicated `*_coverage.go`, `*_presence.go`, `*_correlation.go`, `*_health.go` files.
 
@@ -101,6 +103,8 @@ Each handler domain follows this pattern:
 1. Create handler struct with `New*Handlers()` factory
 2. Implement `RegisterTools(registry *mcp.Registry)` method
 3. Register in `internal/handlers/register.go` via `RegisterAllTools()`
+
+`RegisterAllResources(registry)` registers 7 MCP resources (skill:// URI scheme). Called from `initMCPServer` in `cmd/ha-mcp/main.go` after `RegisterAllTools`.
 
 Tool handlers have signature:
 ```go
@@ -165,6 +169,7 @@ Tool actions and parameters are defined in the handler schemas. Non-obvious aspe
 - `manage_helper` — 26 types. **WebSocket helpers** (input_*, counter, timer, schedule): `id` controls entity_id via create-then-update; **Config Entry helpers** (threshold, derivative, integral, group, template_*, utility_meter, min_max, statistics, trend, random_*, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat): `name` controls entity_id. Multi-step flows: statistics=3, filter=2, trend settings excludes name
 - `manage_hacs` — actions: list, info, get, releases, release_notes, critical, download, uninstall, add_repository, remove_repository, refresh, toggle_beta. All list filters (search, category, installed_only, pending_update) are client-side
 - `manage_system_log` — actions: list, clear. Uses `system_log/list` WS command (bounded to ~50 entries, no HA-side filter params — all filtering is client-side post-fetch). `clear` uses `system_log/clear`. No caching (logs are volatile). Handler: `internal/handlers/system_log.go`
+- `get_skill` — actions: list, read. Fallback for tool-only clients; same content served as skill://ha-mcp/* resources. Handler: `internal/handlers/skill.go`
 - All `manage_*` CRUD tools support Smart Wait (post-mutation polling, see below)
 
 **Label/Alias Array Mode (manage_entity, manage_device, manage_area, manage_floor):**

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server that provides AI assistants with access to
 
 ## Features
 
-- **39 Specialized Tools**: Entity queries, automation CRUD, helper management, scripts, scenes, devices, areas, labels, floors, zones, persons, tags, traces, blueprints, updates, todos, calendars, cameras, dashboards, system log, and more
+- **40 Specialized Tools**: Entity queries, automation CRUD, helper management, scripts, scenes, devices, areas, labels, floors, zones, persons, tags, traces, blueprints, updates, todos, calendars, cameras, dashboards, system log, and more
 - **Hybrid Architecture**: WebSocket for most operations, REST API for automation/script/scene CRUD
 - **Complete CRUD**: Create, read, update, delete automations/scripts/scenes/helpers
 - **Deep System Access**: Query registries, analyze dependencies, access logbook, validate config
@@ -33,7 +33,7 @@ Choose ha-mcp if you need:
 - Advanced analysis (dependencies, cross-references, automation coverage)
 - System administration (registry queries, config validation, logbook, history)
 - Media management (browser, camera streams), HACS, and dashboard access
-- Reliable LLM tool selection — 39 consolidated tools reduce selection errors compared to 95+ fine-grained alternatives
+- Reliable LLM tool selection — 40 consolidated tools reduce selection errors compared to 95+ fine-grained alternatives
 
 Choose the official integration if you need entity-level security or no external infrastructure.
 
@@ -127,7 +127,9 @@ See [docs/configuration.md](docs/configuration.md) for Cline, opencode, and othe
 
 ## Available Tools
 
-39 tools organized by domain. Full reference at [docs/tools.md](docs/tools.md).
+40 tools organized by domain. Full reference at [docs/tools.md](docs/tools.md).
+
+Seven guidance topics are also available as MCP resources under `skill://ha-mcp/<slug>` URIs (format-selection, automation-patterns, template-resilience, helper-selection, dashboard-safety, entity-renaming, debugging-workflow).
 
 | Category          | Count | Highlights                                                                  |
 | ----------------- | ----- | --------------------------------------------------------------------------- |
@@ -144,6 +146,7 @@ See [docs/configuration.md](docs/configuration.md) for Cline, opencode, and othe
 | System/Admin      | 7     | `get_system_info`, `validate_config`, `manage_update`, `manage_blueprint`   |
 | Logs              | 1     | `manage_system_log` (list WARN/ERROR entries, clear ring buffer)            |
 | HACS              | 1     | `manage_hacs` (list, download, install, custom repos)                       |
+| Guidance          | 1     | `get_skill` (action=list to discover skills, action=read to fetch content)  |
 
 ## Access Control
 

--- a/cmd/ha-mcp/main.go
+++ b/cmd/ha-mcp/main.go
@@ -347,8 +347,10 @@ func (a *App) initMCPServer(
 ) (*mcp.Server, error) {
 	registry := mcp.NewRegistry()
 	handlers.RegisterAllTools(registry)
+	handlers.RegisterAllResources(registry)
 
 	logger.Info("Registered MCP tools", "count", registry.ToolCount())
+	logger.Info("Registered MCP resources", "count", registry.ResourceCount())
 	registry.LogRegisteredTools(logger)
 
 	filterCfg := mcp.ToolFilterConfig{

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,9 @@ ha-mcp/
 │   │   ├── calendars.go         # Calendar management handler (list/get_events/create_event/delete_event)
 │   │   ├── cameras.go           # Camera handler (snapshot/stream)
 │   │   ├── waiter.go             # Post-mutation wait utilities (state diff detection)
+│   │   ├── skill.go             # get_skill tool + RegisterAllResources (7 skill:// resources)
+│   │   ├── skills/              # Embedded skill markdown content + catalog (go:embed)
+│   │   │   └── catalog.go       # Skill catalog; add slug here + .md file when adding a skill
 │   │   └── register.go          # Handler registration
 │   └── logging/
 │       └── logger.go            # Structured logging

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -8,7 +8,7 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 
 | Project | Description |
 | ------- | ----------- |
-| **ha-mcp** (this project) | Go binary, 39 specialized tools, HTTP JSON-RPC transport |
+| **ha-mcp** (this project) | Go binary, 40 specialized tools, HTTP JSON-RPC transport |
 | **Community ha-mcp** ([homeassistant-ai/ha-mcp](https://github.com/homeassistant-ai/ha-mcp)) | Python/FastMCP package, 95+ tools, stdio/SSE/HTTP/WebSocket transport |
 | **Official HA MCP Server** (built-in integration) | HA integration, ~10 intent-based tools, Streamable HTTP |
 
@@ -21,7 +21,7 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 | **Type**             | Standalone Go binary (external server)     | Python package (pip/uvx/Docker/Add-on)                       | HA integration (built-in)                                   |
 | **Transport**        | HTTP JSON-RPC                              | stdio, SSE, HTTP, WebSocket                                  | Streamable HTTP                                             |
 | **HA Communication** | WebSocket + REST API (Hybrid)              | WebSocket + REST API                                         | Direct Python API (internal)                                |
-| **Tool Design**      | 39 specialized tools with granular control | 95+ specialized tools                                        | Dynamically generated tools from Assist API (~10 tools)     |
+| **Tool Design**      | 40 specialized tools with granular control | 95+ specialized tools                                        | Dynamically generated tools from Assist API (~10 tools)     |
 | **Authentication**   | Long-Lived Access Token                    | Long-Lived Token + OAuth (beta)                              | OAuth (IndieAuth) + Long-Lived Token                        |
 | **Access Control**   | Tool-level filtering (read-only, whitelist/blacklist, action-level) | Entity/Service allow/deny lists with wildcard patterns | Entity-level exposure (Voice Assistant Exposure) |
 
@@ -248,14 +248,14 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 
 | Function                    | ha-mcp   | Community ha-mcp                                                         | Official HA MCP |
 | --------------------------- | -------- | ------------------------------------------------------------------------ | --------------- |
-| Bundled domain knowledge    | ---      | MCP resources via `skill://` URIs (HA domain-specific guidance for AI)   | ---             |
+| Bundled domain knowledge    | `get_skill` tool + `skill://ha-mcp/*` resources (7 topics)          | MCP resources via `skill://` URIs (HA domain-specific guidance for AI)   | ---             |
 
 ---
 
 ## Summary
 
 ### ha-mcp Strengths:
-- **LLM-Optimised Tool Architecture**: 38 consolidated tools with `action` parameters reduce tool-selection errors. LLM benchmarks show accuracy degrades significantly above ~40 parallel tools; the `tool + action` two-level hierarchy is easier to reason over than 95+ equally-ranked options
+- **LLM-Optimised Tool Architecture**: 39 consolidated tools with `action` parameters reduce tool-selection errors. LLM benchmarks show accuracy degrades significantly above ~40 parallel tools; the `tool + action` two-level hierarchy is easier to reason over than 95+ equally-ranked options
 - **CRUD Operations**: Complete create/edit/delete for automations, scripts, scenes, and helpers
 - **Registry Access**: Detailed access to entity, device, and area registries
 - **Analysis**: Entity dependencies, automation targets, cross-references — unique to this project
@@ -309,6 +309,6 @@ Three MCP server projects expose Home Assistant functionality to AI assistants:
 | Read-only mode | ✅ | ❌ | ❌ |
 | Camera stream (HLS) | ✅ | ❌ | ❌ |
 | Media browser | ✅ | ❌ | ❌ |
-| MCP resources / skill URIs | ❌ | ✅ | ❌ |
+| MCP resources / skill URIs | ✅ | ✅ | ❌ |
 | No external server needed | ❌ | ❌ | ✅ |
 | Standards OAuth (IndieAuth) | ❌ | ❌ (beta only) | ✅ |

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -111,6 +111,12 @@ go test -tags=integration -v ./internal/handlers/integration/... 2>&1 | tee test
 | `TestCameraIntegration`    | list cameras, stream (HLS URL via manage_camera), get_snapshot (binary image data)                  |
 | `TestSystemLogIntegration` | GetSystemLog (list), ClearSystemLog (clear + verify empty)                                           |
 
+**Documented Exception (unit tests only):**
+
+| Tool        | Scope           | Reason                                                                                                                                     |
+| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `get_skill` | Unit tests only | No HA interaction — content is embedded markdown; integration test not technically applicable (documented exception per CLAUDE.md policy). |
+
 **Note:** Read-only tests (traces, updates, blueprints, cameras) verify API integration and response parsing. They skip gracefully if no entities exist or features are unavailable.
 
 ## Test Entity Naming Convention

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -269,6 +269,28 @@ Universal tool for runtime helper operations:
 | `list`  | read   | Fetch recent WARNING/ERROR entries (~50 max by default) | `level`, `integration`, `limit`, `include_exception`, `format` |
 | `clear` | write  | Empty the in-memory ring buffer                      | —                                                       |
 
+### Guidance Tools
+
+| Tool        | Actions    | Description                                                                                                                                                                                  |
+| ----------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_skill` | list, read | Retrieve embedded skill guidance topics. `action=list` shows all available skills; `action=read` with `skill=<slug>` fetches full guidance. Fallback for tool-only clients; resource-aware clients use `skill://ha-mcp/*` resources. |
+
+## Guidance Resources (`skill://`)
+
+ha-mcp exposes 7 embedded guidance documents as MCP resources under the `skill://ha-mcp/` URI prefix.
+Resource-aware clients (Claude Desktop, Cline, etc.) can discover them via `resources/list` and fetch with `resources/read`.
+Tool-only clients (claude.ai web) can use `get_skill` instead.
+
+| URI                                    | Topic                | Covers                                                      |
+| -------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| `skill://ha-mcp/format-selection`      | Format Selection     | When to use natural vs. json format                         |
+| `skill://ha-mcp/automation-patterns`   | Automation Patterns  | Modes, trigger IDs, motion+timer, conditions vs. templates  |
+| `skill://ha-mcp/template-resilience`   | Template Resilience  | has_value() guards, unavailable handling, render_template   |
+| `skill://ha-mcp/helper-selection`      | Helper Selection     | 26-type decision matrix; id vs. name rules                  |
+| `skill://ha-mcp/dashboard-safety`      | Dashboard Safety     | Backup-first, truncation risk, patch workflow               |
+| `skill://ha-mcp/entity-renaming`       | Entity Renaming      | Safe rename workflow, slugify traps, area/label modes       |
+| `skill://ha-mcp/debugging-workflow`    | Debugging Workflow   | Logbook correlation, trace inspection, system log triage    |
+
 ## Output Formats
 
 Most tools support two output formats via the `format` parameter:

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -144,6 +144,12 @@ func RegisterDeviceManageTools(registry *mcp.Registry) {
 	h.RegisterTools(registry)
 }
 
+// RegisterSkillTools registers the get_skill tool (fallback for tool-only MCP clients).
+func RegisterSkillTools(registry *mcp.Registry) {
+	h := NewSkillHandlers()
+	h.RegisterTools(registry)
+}
+
 // RegisterAllTools registers all available tool handlers with the registry.
 // All handlers use the WebSocket API for communication with Home Assistant.
 func RegisterAllTools(registry *mcp.Registry) {
@@ -232,4 +238,7 @@ func RegisterAllTools(registry *mcp.Registry) {
 
 	// Camera tools (snapshot and stream access)
 	RegisterCameraTools(registry)
+
+	// Skill tool — fallback for tool-only clients that cannot access skill:// resources
+	RegisterSkillTools(registry)
 }

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -238,7 +238,5 @@ func RegisterAllTools(registry *mcp.Registry) {
 
 	// Camera tools (snapshot and stream access)
 	RegisterCameraTools(registry)
-
-	// Skill tool — fallback for tool-only clients that cannot access skill:// resources
 	RegisterSkillTools(registry)
 }

--- a/internal/handlers/register_test.go
+++ b/internal/handlers/register_test.go
@@ -152,6 +152,22 @@ func TestRegisterDeviceManageTools(t *testing.T) {
 	}
 }
 
+func TestRegisterSkillTools(t *testing.T) {
+	t.Parallel()
+
+	registry := mcp.NewRegistry()
+	RegisterSkillTools(registry)
+
+	tools := registry.ListTools()
+	if len(tools) != 1 {
+		t.Errorf("RegisterSkillTools() registered %d tools, want 1", len(tools))
+	}
+
+	if len(tools) > 0 && tools[0].Name != "get_skill" {
+		t.Errorf("RegisterSkillTools() registered %q, want get_skill", tools[0].Name)
+	}
+}
+
 func TestRegisterAllTools(t *testing.T) {
 	t.Parallel()
 
@@ -197,6 +213,8 @@ func TestRegisterAllTools(t *testing.T) {
 		"get_datetime",
 		// Config entries (consolidated)
 		"manage_config_entry",
+		// Skill guidance (tool-only client fallback)
+		"get_skill",
 	}
 
 	toolMap := make(map[string]bool)

--- a/internal/handlers/skill.go
+++ b/internal/handlers/skill.go
@@ -190,6 +190,12 @@ func (h *SkillHandlers) handleSkillReadJSON(slug, body string) (*mcp.ToolsCallRe
 			break
 		}
 	}
+	if meta.Slug == "" {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("internal: no catalog entry for slug %q", slug))},
+			IsError: true,
+		}, nil
+	}
 	type result struct {
 		Slug        string `json:"slug"`
 		Name        string `json:"name"`

--- a/internal/handlers/skill.go
+++ b/internal/handlers/skill.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/zorak1103/ha-mcp/internal/handlers/skills"
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/mcp"
+)
+
+const (
+	skillActionList = "list"
+	skillActionRead = "read"
+	skillMimeType   = "text/markdown"
+)
+
+// RegisterAllResources registers all ha-mcp skill:// resources with the registry.
+// Each skill is served as an MCP resource with URI skill://ha-mcp/<slug>.
+// Resource content is embedded markdown; no HA client call is made.
+func RegisterAllResources(registry *mcp.Registry) {
+	for _, meta := range skills.Catalog {
+		registry.RegisterResource(
+			mcp.Resource{
+				URI:         meta.URI(),
+				Name:        meta.Name,
+				Description: meta.Description,
+				MimeType:    skillMimeType,
+			},
+			makeSkillResourceHandler(meta.Slug),
+		)
+	}
+}
+
+// makeSkillResourceHandler returns a ResourceHandler for the given skill slug.
+// The handler reads the embedded markdown and returns it as a resource content block.
+func makeSkillResourceHandler(slug string) mcp.ResourceHandler {
+	return func(_ context.Context, _ homeassistant.Client, uri string) (*mcp.ResourcesReadResult, error) {
+		body, err := skills.Read(slug)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read skill resource %q: %w", uri, err)
+		}
+		return &mcp.ResourcesReadResult{
+			Contents: []mcp.ResourceContent{
+				{
+					URI:      uri,
+					MimeType: skillMimeType,
+					Text:     body,
+				},
+			},
+		}, nil
+	}
+}
+
+// SkillHandlers provides the get_skill tool — a fallback for tool-only MCP clients
+// that do not support the resources/list and resources/read protocol methods.
+type SkillHandlers struct{}
+
+// NewSkillHandlers creates a new SkillHandlers instance.
+func NewSkillHandlers() *SkillHandlers {
+	return &SkillHandlers{}
+}
+
+// RegisterTools registers the get_skill tool with the registry.
+func (h *SkillHandlers) RegisterTools(registry *mcp.Registry) {
+	registry.RegisterTool(h.getSkillTool(), h.handleGetSkill)
+}
+
+// getSkillTool returns the tool definition for get_skill.
+func (h *SkillHandlers) getSkillTool() mcp.Tool {
+	return mcp.Tool{
+		Name: "get_skill",
+		Description: "Retrieve ha-mcp skill guidance. Use action=list to see available topics, " +
+			"action=read with skill=<slug> to fetch full guidance for a topic. " +
+			"For resource-aware MCP clients, the same content is available as skill://ha-mcp/<slug> resources.",
+		InputSchema: mcp.JSONSchema{
+			Type: "object",
+			Properties: map[string]mcp.JSONSchema{
+				"action": {
+					Type:        "string",
+					Enum:        []string{skillActionList, skillActionRead},
+					Description: "Action: 'list' to see all available skills, 'read' to fetch a specific skill by slug",
+				},
+				"skill": {
+					Type:        "string",
+					Description: "Skill slug to read (required for action=read). Use action=list to discover valid slugs.",
+				},
+				"format": {
+					Type:        "string",
+					Enum:        []string{formatNatural, formatJSON},
+					Description: "Output format: 'natural' for readable text (default), 'json' for structured data",
+				},
+			},
+			Required: []string{"action"},
+		},
+	}
+}
+
+// handleGetSkill dispatches list and read actions.
+func (h *SkillHandlers) handleGetSkill(
+	_ context.Context,
+	_ homeassistant.Client,
+	args map[string]any,
+) (*mcp.ToolsCallResult, error) {
+	action := getString(args, "action")
+	switch action {
+	case skillActionList:
+		return h.handleSkillList(args)
+	case skillActionRead:
+		return h.handleSkillRead(args)
+	default:
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{
+				mcp.NewTextContent(fmt.Sprintf("invalid action %q: must be one of [list, read]", action)),
+			},
+			IsError: true,
+		}, nil
+	}
+}
+
+// handleSkillList returns the skill catalog.
+func (h *SkillHandlers) handleSkillList(args map[string]any) (*mcp.ToolsCallResult, error) {
+	if getString(args, "format") == formatJSON {
+		return h.handleSkillListJSON()
+	}
+	return h.handleSkillListNatural()
+}
+
+func (h *SkillHandlers) handleSkillListNatural() (*mcp.ToolsCallResult, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Available ha-mcp skills (%d total). Use action=read with skill=<slug> for full guidance.\n\n", len(skills.Catalog))
+	for _, m := range skills.Catalog {
+		fmt.Fprintf(&sb, "- **%s** (`%s`): %s\n", m.Name, m.Slug, m.Description)
+	}
+	return &mcp.ToolsCallResult{Content: []mcp.ContentBlock{mcp.NewTextContent(sb.String())}}, nil
+}
+
+func (h *SkillHandlers) handleSkillListJSON() (*mcp.ToolsCallResult, error) {
+	type entry struct {
+		Slug        string `json:"slug"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		URI         string `json:"uri"`
+	}
+	entries := make([]entry, 0, len(skills.Catalog))
+	for _, m := range skills.Catalog {
+		entries = append(entries, entry{
+			Slug:        m.Slug,
+			Name:        m.Name,
+			Description: m.Description,
+			URI:         m.URI(),
+		})
+	}
+	b, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("error formatting catalog: %v", err))},
+			IsError: true,
+		}, nil
+	}
+	return &mcp.ToolsCallResult{Content: []mcp.ContentBlock{mcp.NewTextContent(string(b))}}, nil
+}
+
+// handleSkillRead fetches and returns a single skill's markdown.
+func (h *SkillHandlers) handleSkillRead(args map[string]any) (*mcp.ToolsCallResult, error) {
+	slug := getString(args, "skill")
+	if slug == "" {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent("skill is required for action=read")},
+			IsError: true,
+		}, nil
+	}
+	body, err := skills.Read(slug)
+	if err != nil {
+		return h.unknownSkillError(slug)
+	}
+	if getString(args, "format") == formatJSON {
+		return h.handleSkillReadJSON(slug, body)
+	}
+	return &mcp.ToolsCallResult{Content: []mcp.ContentBlock{mcp.NewTextContent(body)}}, nil
+}
+
+func (h *SkillHandlers) handleSkillReadJSON(slug, body string) (*mcp.ToolsCallResult, error) {
+	var meta skills.SkillMeta
+	for _, m := range skills.Catalog {
+		if m.Slug == slug {
+			meta = m
+			break
+		}
+	}
+	type result struct {
+		Slug        string `json:"slug"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		URI         string `json:"uri"`
+		Content     string `json:"content"`
+	}
+	r := result{
+		Slug:        meta.Slug,
+		Name:        meta.Name,
+		Description: meta.Description,
+		URI:         meta.URI(),
+		Content:     body,
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return &mcp.ToolsCallResult{
+			Content: []mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("error formatting result: %v", err))},
+			IsError: true,
+		}, nil
+	}
+	return &mcp.ToolsCallResult{Content: []mcp.ContentBlock{mcp.NewTextContent(string(b))}}, nil
+}
+
+func (h *SkillHandlers) unknownSkillError(slug string) (*mcp.ToolsCallResult, error) {
+	validSlugs := make([]string, 0, len(skills.Catalog))
+	for _, m := range skills.Catalog {
+		validSlugs = append(validSlugs, m.Slug)
+	}
+	msg := fmt.Sprintf("unknown skill %q; valid slugs: %s", slug, strings.Join(validSlugs, ", "))
+	return &mcp.ToolsCallResult{
+		Content: []mcp.ContentBlock{mcp.NewTextContent(msg)},
+		IsError: true,
+	}, nil
+}

--- a/internal/handlers/skill_test.go
+++ b/internal/handlers/skill_test.go
@@ -36,7 +36,7 @@ func TestRegisterAllResources_URIsAndMimeType(t *testing.T) {
 		if !strings.HasPrefix(r.URI, skills.URIPrefix) {
 			t.Errorf("resource URI %q does not start with %q", r.URI, skills.URIPrefix)
 		}
-		if r.MimeType != "text/markdown" {
+		if r.MimeType != skillMimeType {
 			t.Errorf("resource %q MimeType = %q, want text/markdown", r.URI, r.MimeType)
 		}
 		if r.Name == "" {
@@ -73,7 +73,7 @@ func TestRegisterAllResources_HandlersReturnContent(t *testing.T) {
 		if result.Contents[0].URI != r.URI {
 			t.Errorf("handler for %q returned content with URI %q, want %q", r.URI, result.Contents[0].URI, r.URI)
 		}
-		if result.Contents[0].MimeType != "text/markdown" {
+		if result.Contents[0].MimeType != skillMimeType {
 			t.Errorf("handler for %q returned content MimeType %q, want text/markdown", r.URI, result.Contents[0].MimeType)
 		}
 	}

--- a/internal/handlers/skill_test.go
+++ b/internal/handlers/skill_test.go
@@ -1,0 +1,180 @@
+// internal/handlers/skill_test.go
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/zorak1103/ha-mcp/internal/handlers/skills"
+	"github.com/zorak1103/ha-mcp/internal/mcp"
+)
+
+// ─── RegisterAllResources ───────────────────────────────────────────────────
+
+func TestRegisterAllResources_Count(t *testing.T) {
+	t.Parallel()
+	registry := mcp.NewRegistry()
+	RegisterAllResources(registry)
+	got := registry.ResourceCount()
+	want := len(skills.Catalog)
+	if got != want {
+		t.Errorf("ResourceCount() = %d, want %d", got, want)
+	}
+}
+
+func TestRegisterAllResources_URIsAndMimeType(t *testing.T) {
+	t.Parallel()
+	registry := mcp.NewRegistry()
+	RegisterAllResources(registry)
+	seen := make(map[string]bool)
+	for _, r := range registry.ListResources() {
+		if seen[r.URI] {
+			t.Errorf("duplicate resource URI %q", r.URI)
+		}
+		seen[r.URI] = true
+		if !strings.HasPrefix(r.URI, skills.URIPrefix) {
+			t.Errorf("resource URI %q does not start with %q", r.URI, skills.URIPrefix)
+		}
+		if r.MimeType != "text/markdown" {
+			t.Errorf("resource %q MimeType = %q, want text/markdown", r.URI, r.MimeType)
+		}
+		if r.Name == "" {
+			t.Errorf("resource %q has empty Name", r.URI)
+		}
+		if r.Description == "" {
+			t.Errorf("resource %q has empty Description", r.URI)
+		}
+	}
+}
+
+func TestRegisterAllResources_HandlersReturnContent(t *testing.T) {
+	t.Parallel()
+	registry := mcp.NewRegistry()
+	RegisterAllResources(registry)
+	for _, r := range registry.ListResources() {
+		handler, ok := registry.GetResourceHandler(r.URI)
+		if !ok {
+			t.Errorf("no handler found for resource %q", r.URI)
+			continue
+		}
+		result, err := handler(context.Background(), &UniversalMockClient{}, r.URI)
+		if err != nil {
+			t.Errorf("handler for %q returned error: %v", r.URI, err)
+			continue
+		}
+		if len(result.Contents) == 0 {
+			t.Errorf("handler for %q returned no contents", r.URI)
+			continue
+		}
+		if result.Contents[0].Text == "" {
+			t.Errorf("handler for %q returned empty text", r.URI)
+		}
+		if result.Contents[0].URI != r.URI {
+			t.Errorf("handler for %q returned content with URI %q, want %q", r.URI, result.Contents[0].URI, r.URI)
+		}
+		if result.Contents[0].MimeType != "text/markdown" {
+			t.Errorf("handler for %q returned content MimeType %q, want text/markdown", r.URI, result.Contents[0].MimeType)
+		}
+	}
+}
+
+// ─── SkillHandlers tool registration ────────────────────────────────────────
+
+func TestSkillHandlers_RegisterTools(t *testing.T) {
+	t.Parallel()
+	h := NewSkillHandlers()
+	registry := mcp.NewRegistry()
+	h.RegisterTools(registry)
+	tools := registry.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("RegisterTools() registered %d tools, want 1", len(tools))
+	}
+	if tools[0].Name != "get_skill" {
+		t.Errorf("tool name = %q, want get_skill", tools[0].Name)
+	}
+}
+
+func TestSkillHandlers_Schema(t *testing.T) {
+	t.Parallel()
+	h := NewSkillHandlers()
+	tool := h.getSkillTool()
+	verifyToolSchema(t, tool, toolSchemaExpectation{
+		ExpectedName:    "get_skill",
+		RequiredParams:  []string{"action"},
+		OptionalParams:  []string{"skill", "format"},
+		WantDescription: true,
+	})
+}
+
+// ─── handleGetSkill behavior ─────────────────────────────────────────────────
+
+func TestSkillHandlers_HandleGetSkill(t *testing.T) {
+	t.Parallel()
+	h := NewSkillHandlers()
+	tests := []handlerTestCase{
+		{
+			name:      "list natural lists all 7 slugs",
+			args:      map[string]any{"action": "list"},
+			wantError: false,
+			wantContains: []string{
+				"format-selection",
+				"automation-patterns",
+				"template-resilience",
+				"helper-selection",
+				"dashboard-safety",
+				"entity-renaming",
+				"debugging-workflow",
+			},
+		},
+		{
+			name:         "list json returns structured output with slug field",
+			args:         map[string]any{"action": "list", "format": "json"},
+			wantError:    false,
+			wantContains: []string{"format-selection", `"slug"`},
+		},
+		{
+			name:         "read valid skill returns non-empty content",
+			args:         map[string]any{"action": "read", "skill": "format-selection"},
+			wantError:    false,
+			wantContains: []string{"natural", "json"},
+		},
+		{
+			name:         "read automation-patterns returns mode table",
+			args:         map[string]any{"action": "read", "skill": "automation-patterns"},
+			wantError:    false,
+			wantContains: []string{"restart", "queued", "parallel"},
+		},
+		{
+			name:         "read json format returns slug and content fields",
+			args:         map[string]any{"action": "read", "skill": "debugging-workflow", "format": "json"},
+			wantError:    false,
+			wantContains: []string{`"slug"`, `"content"`, "debugging-workflow"},
+		},
+		{
+			name:         "read unknown slug returns IsError with slug name and valid slugs listed",
+			args:         map[string]any{"action": "read", "skill": "bogus-unknown-slug"},
+			wantError:    true,
+			wantContains: []string{"bogus-unknown-slug", "format-selection"},
+		},
+		{
+			name:         "read missing skill param returns IsError",
+			args:         map[string]any{"action": "read"},
+			wantError:    true,
+			wantContains: []string{"skill is required"},
+		},
+		{
+			name:         "invalid action returns IsError",
+			args:         map[string]any{"action": "delete"},
+			wantError:    true,
+			wantContains: []string{"invalid action", "delete"},
+		},
+		{
+			name:         "missing action treated as invalid",
+			args:         map[string]any{},
+			wantError:    true,
+			wantContains: []string{"invalid action"},
+		},
+	}
+	runHandlerTestCases(t, tests, h.handleGetSkill)
+}

--- a/internal/handlers/skills/automation-patterns.md
+++ b/internal/handlers/skills/automation-patterns.md
@@ -1,0 +1,1 @@
+# Automation Patterns

--- a/internal/handlers/skills/automation-patterns.md
+++ b/internal/handlers/skills/automation-patterns.md
@@ -1,1 +1,98 @@
 # Automation Patterns
+
+Practical patterns for creating and editing automations with `manage_automation`.
+
+## Mode selection
+
+| Mode       | Behavior when triggered while running    | Use for                                     |
+| ---------- | ---------------------------------------- | ------------------------------------------- |
+| `single`   | Ignores new trigger (HA default)         | Most automations; idempotent actions        |
+| `restart`  | Cancels current run, starts fresh        | Motion lights; presence-based scenes        |
+| `queued`   | Queues new runs up to `max` (default 10) | Sequential notifications; ordered actions   |
+| `parallel` | Runs all triggers concurrently           | Independent per-person or per-device flows  |
+
+Pass `mode` and optionally `max` (only meaningful for `queued` and `parallel`) in `create` or `update`.
+
+## Trigger IDs
+
+Give every trigger a unique `id` so you can reference it in conditions and actions:
+
+```yaml
+triggers:
+  - platform: state
+    entity_id: binary_sensor.motion_living_room
+    to: "on"
+    id: motion_on
+  - platform: state
+    entity_id: binary_sensor.motion_living_room
+    to: "off"
+    id: motion_off
+```
+
+Use `trigger.id` in conditions: `"{{ trigger.id == 'motion_on' }}"`.
+
+## Motion + timer pattern
+
+The standard pattern for "lights off after N minutes of no motion":
+
+```yaml
+alias: Living Room Motion Light
+mode: restart
+triggers:
+  - platform: state
+    entity_id: binary_sensor.motion_living_room
+    id: motion
+conditions: []
+actions:
+  - if:
+      - condition: trigger
+        id: motion
+        to: "on"
+    then:
+      - service: light.turn_on
+        target:
+          entity_id: light.living_room
+    else:
+      - delay: "00:05:00"
+      - service: light.turn_off
+        target:
+          entity_id: light.living_room
+```
+
+Use `mode: restart` so a new motion event restarts the 5-minute delay.
+
+## Conditions vs. templates
+
+| Use condition objects when…                          | Use a template condition when…                        |
+| ---------------------------------------------------- | ----------------------------------------------------- |
+| Checking a single entity state or time               | Logic combines multiple entities or requires math     |
+| The HA UI would offer it as a condition type         | The check can't be expressed as a single condition    |
+
+Template condition syntax in an automation:
+```yaml
+conditions:
+  - condition: template
+    value_template: "{{ states('sensor.temperature') | float > 22 }}"
+```
+
+## Creating automations with non-ASCII aliases
+
+HA slugifies `alias` to derive `entity_id`. Non-ASCII characters (umlauts, accents) are stripped:
+`alias: "Büro Licht"` → `entity_id: automation.buro_licht` (not `büro`).
+
+Fix: pass `automation_id` explicitly:
+```json
+{
+  "action": "create",
+  "alias": "Büro Licht",
+  "automation_id": "buro_licht"
+}
+```
+
+## Patching vs. updating
+
+Use `action=patch` for surgical changes (adding/removing triggers, changing mode).
+Use `action=update` only when rewriting the entire automation.
+Always call `action=get` before patching — `action=list` does not populate the Config field.
+
+See `skill://ha-mcp/dashboard-safety` for patch syntax examples.

--- a/internal/handlers/skills/catalog.go
+++ b/internal/handlers/skills/catalog.go
@@ -1,0 +1,76 @@
+// Package skills provides embedded ha-mcp skill guidance for MCP resource delivery.
+// Each skill is a standalone markdown file embedded into the binary at compile time.
+package skills
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed *.md
+var content embed.FS
+
+// URIPrefix is the base URI scheme for all ha-mcp skill resources.
+const URIPrefix = "skill://ha-mcp/"
+
+// SkillMeta describes a single skill exposed as an MCP resource.
+type SkillMeta struct {
+	Slug        string
+	Name        string
+	Description string
+}
+
+// URI returns the MCP resource URI for this skill.
+func (m SkillMeta) URI() string {
+	return URIPrefix + m.Slug
+}
+
+// Catalog is the ordered list of all ha-mcp skills.
+// Slug must be lowercase-kebab and match the corresponding *.md filename exactly.
+var Catalog = []SkillMeta{
+	{
+		Slug:        "format-selection",
+		Name:        "Format Selection",
+		Description: "When to use format=natural (default) vs. format=json — avoid the common token-waste pattern.",
+	},
+	{
+		Slug:        "automation-patterns",
+		Name:        "Automation Patterns",
+		Description: "Mode selection (single/restart/queued/parallel), trigger IDs, motion+timer pattern, conditions vs. templates.",
+	},
+	{
+		Slug:        "template-resilience",
+		Name:        "Template Resilience",
+		Description: "has_value() guards, unavailable/unknown handling, validating templates with render_template before deploy.",
+	},
+	{
+		Slug:        "helper-selection",
+		Name:        "Helper Selection",
+		Description: "Decision matrix for 26 helper types; id vs. name parameter rules; built-in vs. template sensor trade-offs.",
+	},
+	{
+		Slug:        "dashboard-safety",
+		Name:        "Dashboard Safety",
+		Description: "Backup-first pattern, large-config truncation risk, when to use the HA UI Raw Config Editor vs. the API.",
+	},
+	{
+		Slug:        "entity-renaming",
+		Name:        "Entity Renaming",
+		Description: "Safe rename workflow, area/label patterns, manage_entity update quirks and slugify traps.",
+	},
+	{
+		Slug:        "debugging-workflow",
+		Name:        "Debugging Workflow",
+		Description: "get_logbook(mode=correlation) for timing analysis, batch get_state, trace inspection, system log triage.",
+	},
+}
+
+// Read returns the markdown content for the given skill slug.
+// Returns an error if the slug is not in the embedded filesystem.
+func Read(slug string) (string, error) {
+	b, err := content.ReadFile(slug + ".md")
+	if err != nil {
+		return "", fmt.Errorf("unknown skill %q", slug)
+	}
+	return string(b), nil
+}

--- a/internal/handlers/skills/catalog_test.go
+++ b/internal/handlers/skills/catalog_test.go
@@ -1,0 +1,92 @@
+// internal/handlers/skills/catalog_test.go
+package skills_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zorak1103/ha-mcp/internal/handlers/skills"
+)
+
+func TestCatalog_Length(t *testing.T) {
+	t.Parallel()
+	const want = 7
+	if len(skills.Catalog) != want {
+		t.Errorf("Catalog has %d entries, want %d", len(skills.Catalog), want)
+	}
+}
+
+func TestCatalog_Slugs_UniqueAndKebab(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]bool)
+	for _, m := range skills.Catalog {
+		if m.Slug == "" {
+			t.Error("found empty slug in Catalog")
+		}
+		if m.Slug != strings.ToLower(m.Slug) {
+			t.Errorf("slug %q is not lowercase", m.Slug)
+		}
+		if strings.Contains(m.Slug, " ") || strings.Contains(m.Slug, "_") {
+			t.Errorf("slug %q must be kebab-case (no spaces or underscores)", m.Slug)
+		}
+		if seen[m.Slug] {
+			t.Errorf("duplicate slug %q in Catalog", m.Slug)
+		}
+		seen[m.Slug] = true
+	}
+}
+
+func TestCatalog_AllHaveNameAndDescription(t *testing.T) {
+	t.Parallel()
+	for _, m := range skills.Catalog {
+		if m.Name == "" {
+			t.Errorf("skill %q has empty Name", m.Slug)
+		}
+		if m.Description == "" {
+			t.Errorf("skill %q has empty Description", m.Slug)
+		}
+	}
+}
+
+func TestCatalog_URIs(t *testing.T) {
+	t.Parallel()
+	for _, m := range skills.Catalog {
+		uri := m.URI()
+		wantURI := skills.URIPrefix + m.Slug
+		if uri != wantURI {
+			t.Errorf("skill %q URI = %q, want %q", m.Slug, uri, wantURI)
+		}
+		if !strings.HasPrefix(uri, "skill://ha-mcp/") {
+			t.Errorf("skill %q URI %q does not start with skill://ha-mcp/", m.Slug, uri)
+		}
+	}
+}
+
+func TestRead_ValidSlugs(t *testing.T) {
+	t.Parallel()
+	for _, m := range skills.Catalog {
+		content, err := skills.Read(m.Slug)
+		if err != nil {
+			t.Errorf("Read(%q) error = %v", m.Slug, err)
+			continue
+		}
+		if content == "" {
+			t.Errorf("Read(%q) returned empty content", m.Slug)
+		}
+		// Every skill must have at least a heading
+		if !strings.Contains(content, "#") {
+			t.Errorf("Read(%q) content missing markdown heading", m.Slug)
+		}
+	}
+}
+
+func TestRead_InvalidSlug(t *testing.T) {
+	t.Parallel()
+	_, err := skills.Read("bogus-nonexistent-slug-xyz")
+	if err == nil {
+		t.Error("Read(bogus) should return an error, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "bogus-nonexistent-slug-xyz") {
+		t.Errorf("error should mention the slug, got: %v", err)
+	}
+}

--- a/internal/handlers/skills/dashboard-safety.md
+++ b/internal/handlers/skills/dashboard-safety.md
@@ -1,1 +1,76 @@
 # Dashboard Safety
+
+Dashboards are the highest-risk entities to edit via API. A malformed save can corrupt the UI.
+Follow this pattern to work safely.
+
+## Backup before any write
+
+Always fetch the current config before modifying it:
+
+```json
+{ "action": "get", "dashboard_url_path": "lovelace" }
+```
+
+Save the returned config. If anything goes wrong, you can restore it with `action=save_config` or `action=update`.
+
+## Use patch for surgical edits
+
+`action=patch` applies targeted changes atomically — if any operation fails, the dashboard is unchanged:
+
+```json
+{
+  "action": "patch",
+  "dashboard_url_path": "lovelace",
+  "operations": [
+    {
+      "op": "replace",
+      "match": {"title": "Weather"},
+      "section": "views",
+      "field": "cards",
+      "value": []
+    }
+  ]
+}
+```
+
+**Always call `action=get` before patching.** `action=list` does not populate the Config field.
+
+## Large config truncation risk
+
+HA dashboard configs can exceed 100 KB. The MCP text response has practical limits.
+
+Signs of truncation:
+- Response ends mid-JSON or mid-YAML
+- `get` returns fewer views than expected
+- Patch fails with "path not found" on a view that should exist
+
+Mitigation:
+- Work with one view at a time using the `path` or semantic `match` ops
+- Use `format=json` when you need exact field values to round-trip back to an update
+- For large configs, prefer the HA UI Raw Config Editor over the API
+
+## When to use the HA UI Raw Config Editor instead
+
+Prefer the HA UI editor when:
+- The config is > 50 KB
+- You need to copy-paste large card configurations
+- You're doing a wholesale restructure of multiple views
+- The dashboard uses custom cards not representable as simple JSON
+
+Prefer the API when:
+- Making targeted changes to known paths (card properties, entity lists)
+- Automating repetitive changes across multiple dashboards
+- Bulk-replacing an entity ID across all actions in a view
+
+## Patch operations for dashboards
+
+| Goal                                          | Op type  | Example                                                          |
+| --------------------------------------------- | -------- | ---------------------------------------------------------------- |
+| Replace a view's card list by title           | semantic | `match: {title: "Living Room"}, section: views, field: cards`    |
+| Add a card to a view                          | standard | `path: /views/0/cards/-`                                         |
+| Remove a specific card by type+entity         | semantic | `match: {type: "entity", entity: "light.x"}, section: views/0/cards` |
+| Change a view's title                         | standard | `path: /views/0/title, value: "New Title"`                       |
+
+## Dashboard atomicity
+
+All patch operations on a dashboard apply as a unit — first failure rolls back all. You cannot partially save a corrupted dashboard via patch. Standard (path-based) `remove` ops: sort descending by index when issuing multiple removes.

--- a/internal/handlers/skills/dashboard-safety.md
+++ b/internal/handlers/skills/dashboard-safety.md
@@ -1,0 +1,1 @@
+# Dashboard Safety

--- a/internal/handlers/skills/debugging-workflow.md
+++ b/internal/handlers/skills/debugging-workflow.md
@@ -1,0 +1,1 @@
+# Debugging Workflow

--- a/internal/handlers/skills/debugging-workflow.md
+++ b/internal/handlers/skills/debugging-workflow.md
@@ -1,1 +1,90 @@
 # Debugging Workflow
+
+A step-by-step process for diagnosing why an automation, script, or entity is behaving unexpectedly.
+
+## Step 1: Check the entity state
+
+```json
+{ "tool": "get_state", "entity_ids": ["automation.my_auto", "binary_sensor.motion", "light.living_room"] }
+```
+
+Use the `entity_ids` array form to check all relevant entities in one call. Look for `unavailable`, `unknown`, or unexpected state values.
+
+## Step 2: Look for timing patterns in the logbook
+
+```json
+{
+  "tool": "get_logbook",
+  "mode": "correlation",
+  "entity_id": "automation.my_auto",
+  "start_time": "2024-01-15T00:00:00",
+  "end_time": "2024-01-15T23:59:59"
+}
+```
+
+`mode=correlation` groups related events by causal chain — trigger → action → state change. This shows whether the automation fired, what triggered it, and what happened to dependent entities afterward.
+
+Use `mode=entries` for a raw chronological log.
+
+## Step 3: Inspect the last execution trace
+
+```json
+{ "tool": "manage_trace", "action": "list", "domain": "automation", "entity_id": "automation.my_auto" }
+```
+
+Always pass `domain` — it is required despite the schema marking it optional.
+
+Then fetch the most recent trace:
+```json
+{ "tool": "manage_trace", "action": "get", "domain": "automation", "trace_id": "<id from list>", "entity_id": "automation.my_auto" }
+```
+
+The trace shows exactly which conditions passed/failed and which actions executed.
+
+## Step 4: Validate any templates
+
+```json
+{ "tool": "render_template", "template": "{{ states('sensor.temperature') | float > 22 }}" }
+```
+
+Test every template condition in the automation against the live HA state before assuming it works. A template returning `unavailable` or an error string will always evaluate to falsy.
+
+## Step 5: Check the system log for errors
+
+```json
+{ "tool": "manage_system_log", "action": "list", "level": "error", "integration": "my_integration" }
+```
+
+The system log contains ERROR and WARNING messages from integrations. Filter by `level=error` for the most critical issues. Filter by `integration` (substring match) to narrow to a specific component.
+
+## Step 6: Check entity health
+
+```json
+{ "tool": "query_entities", "mode": "health" }
+```
+
+Returns unavailable, unknown, disabled, orphaned, and stale entities. Stale entities may indicate a device that disconnected.
+
+## Debugging specific failure modes
+
+| Symptom                                                    | Debug tool                                       | What to look for                                      |
+| ---------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| Automation not firing                                      | `manage_trace:list` + `manage_trace:get`         | Condition failures; trace may show zero runs          |
+| Automation fires but action has no effect                  | `get_logbook mode=correlation`                   | State didn't change after action; check call_service  |
+| Sensor reading is wrong / stuck                            | `query_entities mode=health`; `get_state`        | `unavailable` or `unknown` state                      |
+| Integration throwing errors                                | `manage_system_log action=list level=error`      | Look for exception traces from the integration        |
+| Entity disappeared from UI but still in automations        | `analyze_entity` + `query_entities mode=health`  | Orphaned entity; re-add the integration or delete it  |
+| Template condition always passes or always fails           | `render_template`                                | Template syntax error or None value; add `has_value`  |
+
+## Quick reference: read-only diagnostic tools
+
+| Tool                                            | What it reveals                                        |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| `get_state` with `entity_ids: [...]` array      | Current state + attributes for multiple entities       |
+| `get_logbook mode=correlation`                  | Causal chains: trigger → action → state change         |
+| `manage_trace action=get`                       | Per-step execution trace with condition pass/fail      |
+| `render_template`                               | Whether a template evaluates correctly against live HA |
+| `manage_system_log action=list level=error`     | Integration error messages with stack traces           |
+| `query_entities mode=health`                    | Unavailable, stale, orphaned entities                  |
+| `analyze_entity`                                | Which automations/scripts depend on a given entity     |
+| `get_entity_dependencies`                       | Which entities an automation depends on                |

--- a/internal/handlers/skills/entity-renaming.md
+++ b/internal/handlers/skills/entity-renaming.md
@@ -1,1 +1,91 @@
 # Entity Renaming
+
+Renaming an entity in ha-mcp updates the entity registry, not automation configs.
+Follow this workflow to rename safely without breaking automations.
+
+## Safe rename workflow
+
+**Step 1: Check current usage**
+```json
+{ "tool": "analyze_entity", "entity_id": "light.old_name" }
+```
+`analyze_entity` shows every automation, script, and scene that references this entity. Note them — you'll need to update them after renaming.
+
+**Step 2: Rename the entity**
+```json
+{
+  "tool": "manage_entity",
+  "action": "update",
+  "entity_id": "light.old_name",
+  "new_entity_id": "light.new_name",
+  "name": "New Display Name"
+}
+```
+`new_entity_id` renames the entity; `name` updates the friendly name. Both are optional independently.
+
+**Step 3: Reload or wait for Smart Wait**
+The server polls for the state change. If the entity appears under the new ID within 5 seconds, the response includes the confirmation. No manual `get_state` needed.
+
+**Step 4: Update automations and scripts**
+For each automation referencing `light.old_name`, use a semantic patch:
+```json
+{
+  "action": "patch",
+  "automation_id": "my_automation",
+  "operations": [
+    {
+      "op": "replace",
+      "match": {"entity_id": "light.old_name"},
+      "section": "triggers",
+      "field": "entity_id",
+      "value": "light.new_name"
+    },
+    {
+      "op": "replace",
+      "match": {"entity_id": "light.old_name"},
+      "section": "actions",
+      "field": "entity_id",
+      "value": "light.new_name"
+    }
+  ]
+}
+```
+
+## Slugify traps
+
+HA derives `entity_id` from `alias` (automations) or `name` (Config Entry helpers) by slugifying:
+- Non-ASCII characters are stripped: `Büro` → `buro`
+- Spaces → underscores: `Living Room` → `living_room`
+- Uppercase → lowercase
+
+If you rename a helper with a non-ASCII name, the entity_id may change unexpectedly.
+**Fix:** For automations, pass `automation_id` explicitly. For helpers, use ASCII-only names.
+
+## Duplicate entity on automation update
+
+UI-created automations have numeric config IDs that differ from their entity slug.
+Calling `manage_automation:update` with a mismatched ID creates a duplicate entity instead of updating the original.
+
+**Fix:** Always call `manage_automation:get` first. Use `current.Config.ID` (the numeric ID) for the `automation_id` parameter in subsequent updates.
+
+## Area and label assignment
+
+```json
+{
+  "tool": "manage_entity",
+  "action": "update",
+  "entity_id": "light.new_name",
+  "area_id": "living_room",
+  "labels": ["automated", "energy_monitored"],
+  "label_mode": "add"
+}
+```
+
+`label_mode: "add"` (the default) appends labels without overwriting existing ones.
+Use `label_mode: "replace"` to set the exact final list.
+Use `label_mode: "remove"` to subtract specific labels.
+
+## Alias modes (automations, areas, devices)
+
+Same pattern as label modes: `alias_mode: "add"` | `"remove"` | `"replace"`.
+Only applies to `update` actions — `create` always sets the initial values directly.

--- a/internal/handlers/skills/entity-renaming.md
+++ b/internal/handlers/skills/entity-renaming.md
@@ -1,0 +1,1 @@
+# Entity Renaming

--- a/internal/handlers/skills/format-selection.md
+++ b/internal/handlers/skills/format-selection.md
@@ -1,0 +1,1 @@
+# Format Selection

--- a/internal/handlers/skills/format-selection.md
+++ b/internal/handlers/skills/format-selection.md
@@ -1,1 +1,49 @@
-# Format Selection
+# Format Selection: natural vs. json
+
+Most ha-mcp tools accept a `format` parameter. Choosing correctly saves 30–60% of tokens per response.
+
+## Default: Always `format=natural`
+
+`format=natural` is the default. Never override it unless you will programmatically parse the output.
+
+- Produces LLM-optimized prose — easy to reason about, no schema noise.
+- 30–60% fewer tokens than `format=json` for most responses.
+- Describes state, history, lists, and errors in plain English.
+
+## Use `format=json` only when:
+
+1. **Piping to another tool or API call** — you need an exact field value.
+2. **Creating or updating entities** — you must inspect the precise field structure (e.g., `manage_script:get` before a full `update`).
+3. **Processing nested or structured data** — e.g., extracting a specific nested key from a large automation config.
+
+## Decision table
+
+| Scenario                                         | format   | Why                                          |
+| ------------------------------------------------ | -------- | -------------------------------------------- |
+| Status checks, diagnostics, general queries      | natural  | Token-efficient; human-readable reasoning    |
+| Finding which entities are in an area            | natural  | Prose list is enough                         |
+| Reading automation config before a patch         | natural  | You just need to understand the structure    |
+| Reading automation config before a full `update` | json     | You need exact field names and types         |
+| `manage_script:get` before constructing a call   | json     | Sequence/fields must be round-tripped intact |
+| `query_entities` for display / analysis          | natural  | Dense prose beats JSON noise                 |
+| `get_state` for display                          | natural  | State + attributes in plain text             |
+| Extracting a specific field for a subsequent API | json     | Parse the field; pass it to the next call    |
+
+## Anti-pattern: JSON for read-only operations
+
+```
+# WRONG — unnecessary token cost
+manage_automation action=list format=json
+
+# RIGHT
+manage_automation action=list
+# (format=natural is the default — no need to specify)
+```
+
+## Token impact example
+
+A typical `query_entities mode=current domain=light` call:
+- `format=natural` → ~250 tokens
+- `format=json` → ~600 tokens for the same 10 entities
+
+Reserve JSON for when you need it. Natural is the right default for everything else.

--- a/internal/handlers/skills/helper-selection.md
+++ b/internal/handlers/skills/helper-selection.md
@@ -1,0 +1,1 @@
+# Helper Selection

--- a/internal/handlers/skills/helper-selection.md
+++ b/internal/handlers/skills/helper-selection.md
@@ -1,1 +1,61 @@
 # Helper Selection
+
+26 helper types are available via `manage_helper action=create`. Choosing the right type and knowing how entity IDs are derived prevents the most common helper mistakes.
+
+## Entity ID rules (critical)
+
+The parameter that controls the entity ID differs by helper group:
+
+| Helper types                                                                                                                                                               | Entity ID controlled by         | Example                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------- |
+| `input_boolean`, `input_number`, `input_text`, `input_select`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`                                            | `id` parameter                  | `id: my_switch` → `input_boolean.my_switch`           |
+| `threshold`, `derivative`, `integral`, `group`, `template_sensor`, `template_binary_sensor`, `utility_meter`, `min_max`, `statistics`, `trend`, `random_sensor`, `random_binary_sensor`, `filter`, `tod`, `generic_thermostat`, `generic_hygrostat`, `switch_as_x` | `name` parameter (HA slugifies) | `name: "My Sensor"` → `sensor.my_sensor` (ASCII only) |
+
+Non-ASCII characters in `name` are stripped during slugification. Use ASCII names for predictable entity IDs with Config Entry helpers.
+
+## Decision matrix
+
+| Need                                           | Helper type              | Notes                                          |
+| ---------------------------------------------- | ------------------------ | ---------------------------------------------- |
+| On/off toggle the user controls                | `input_boolean`          | Use `id` param for entity_id                   |
+| Numeric slider / setpoint                      | `input_number`           | Requires `min` and `max` on both create/update |
+| Free-text field                                | `input_text`             | Optional `min`/`max` length, `pattern`         |
+| Dropdown list                                  | `input_select`           | Requires `options` array                       |
+| Date or time picker                            | `input_datetime`         | `has_date`, `has_time` booleans                |
+| Pressable button                               | `input_button`           | No state; triggers `pressed` event             |
+| Count events                                   | `counter`                | Optional `step`, `min`, `max`                  |
+| Countdown timer                                | `timer`                  | Optional `duration` in `HH:MM:SS`             |
+| Time-of-day schedule                           | `schedule`               | Calendar-style blocks                          |
+| Computed sensor based on another sensor        | `template_sensor`        | `state_template`, optional `unit`              |
+| Binary sensor derived from logic               | `template_binary_sensor` | `state_template`, optional `device_class`      |
+| Alert when sensor crosses threshold            | `threshold`              | Source must be `sensor.*`                      |
+| Rate of change of a sensor                     | `derivative`             | Source must be `sensor.*`                      |
+| Energy / power integration (kWh)               | `integral`               | Source must be `sensor.*`                      |
+| Group of entities into one state               | `group`                  | `entities` array                               |
+| Track daily/weekly energy usage                | `utility_meter`          | Source must be `sensor.*`; `cycle` required    |
+| Min/max/mean of multiple sensors               | `min_max`                | `entity_ids` array                             |
+| Statistical aggregation over time              | `statistics`             | Source must be `sensor.*`; 3-step flow         |
+| Rising/falling trend detection                 | `trend`                  | Source must be `sensor.*`                      |
+| Random number sensor                           | `random_sensor`          | `minimum`, `maximum`                           |
+| Random binary sensor                           | `random_binary_sensor`   | `chance` (0–100)                               |
+| Filter noisy sensor readings                   | `filter`                 | Source must be `sensor.*`; 2-step flow         |
+| Time-of-day binary (active between times)      | `tod`                    | `after`, `before` times                        |
+| Thermostat from switch + sensor                | `generic_thermostat`     | Switch must be `switch.*`, sensor `sensor.*`   |
+| Humidistat from switch + sensor                | `generic_hygrostat`      | Switch must be `switch.*`, sensor `sensor.*`   |
+| Expose a switch as a cover/fan/light/etc.      | `switch_as_x`            | Switch must be `switch.*`                      |
+
+## Source entity domain requirements
+
+Config Entry helpers that need a sensor (`threshold`, `derivative`, `integral`, `statistics`, `trend`, `filter`, `utility_meter`, `min_max`) require a `sensor.*` entity — not `input_number.*`.
+
+Workaround: wrap `input_number.my_value` in a `template_sensor` that reads its state, then use the template sensor as the source.
+
+Config Entry helpers that need a switch (`generic_thermostat`, `generic_hygrostat`, `switch_as_x`) require a `switch.*` entity — not `input_boolean.*`.
+
+Workaround: wrap `input_boolean.my_flag` in a `template_binary_sensor` with `turn_on`/`turn_off` service actions.
+
+## WebSocket helper updates require ALL mandatory fields
+
+When updating WebSocket-based helpers (`input_*`, `counter`, `timer`, `schedule`), include all mandatory fields in every update — not just the ones changing. For example, `input_number` always needs `min` and `max` even if only `name` is changing.
+
+Use `manage_helper action=get_details` to fetch the current config, then merge your changes before sending the update.

--- a/internal/handlers/skills/template-resilience.md
+++ b/internal/handlers/skills/template-resilience.md
@@ -1,1 +1,90 @@
 # Template Resilience
+
+Jinja2 templates in HA can return `unavailable` or `unknown` and raise errors on None values.
+These patterns prevent automation failures and silent incorrect behavior.
+
+## Always guard numeric sensors with `has_value()`
+
+```yaml
+# FRAGILE — fails when sensor is unavailable
+"{{ states('sensor.temperature') | float > 22 }}"
+
+# RESILIENT — short-circuits when sensor has no valid value
+"{{ states.sensor.temperature | has_value and states('sensor.temperature') | float > 22 }}"
+```
+
+`has_value()` returns `false` if the state is `unavailable`, `unknown`, `None`, or empty.
+
+## Check for unavailable before math or string ops
+
+```yaml
+# Pattern: guard then compute
+{% set temp = states('sensor.temperature') %}
+{% if temp not in ['unavailable', 'unknown', 'none', ''] %}
+  {{ temp | float | round(1) }}
+{% else %}
+  N/A
+{% endif %}
+```
+
+Or using the state object:
+```yaml
+{% if states.sensor.temperature is defined and states.sensor.temperature.state not in ['unavailable', 'unknown'] %}
+  {{ states.sensor.temperature.state | float }}
+{% endif %}
+```
+
+## Elimination logic pattern
+
+When you need a fallback chain across multiple sensors:
+
+```yaml
+{% set sources = [
+    states('sensor.indoor_temp_main'),
+    states('sensor.indoor_temp_backup')
+  ] | select('ne', 'unavailable') | select('ne', 'unknown') | list %}
+{% if sources %}
+  {{ sources[0] | float }}
+{% else %}
+  unavailable
+{% endif %}
+```
+
+## Validate before deploying
+
+Use `render_template` to test your template against the live HA instance before embedding it in an automation:
+
+```json
+{
+  "tool": "render_template",
+  "template": "{{ states.sensor.temperature | has_value and states('sensor.temperature') | float > 22 }}"
+}
+```
+
+Expected: `true` or `false` (not an error string like `TemplateError`).
+If `render_template` returns an error, fix the template before using it in an automation or helper.
+
+## Template sensors and binary sensors
+
+When Config Entry helpers (`statistics`, `trend`, `utility_meter`, `filter`, `generic_thermostat`) need a sensor source but you only have an `input_number`, wrap it:
+
+```yaml
+# Template sensor wrapping input_number.my_value
+template:
+  - sensor:
+      - name: my_value_sensor
+        state: "{{ states('input_number.my_value') }}"
+        unit_of_measurement: "W"
+        device_class: power
+```
+
+Then use `sensor.my_value_sensor` as the source entity for Config Entry helpers.
+
+## Common pitfalls
+
+| Symptom                                      | Cause                                        | Fix                                               |
+| -------------------------------------------- | -------------------------------------------- | ------------------------------------------------- |
+| Template returns `None` or `0` unexpectedly  | Sensor is `unavailable`; `\| float` returns 0 | Add `has_value()` guard before the cast           |
+| Automation runs but condition always passes  | Forgot `\| float` after `states()`            | Cast to float/int before comparing to a number    |
+| `render_template` returns TemplateError      | Undefined variable or wrong attribute name   | Check entity ID spelling; verify attribute exists |
+| Template sensor always `unavailable`         | Source sensor domain not accepted            | Wrap with a template sensor if source is input_*  |

--- a/internal/handlers/skills/template-resilience.md
+++ b/internal/handlers/skills/template-resilience.md
@@ -1,0 +1,1 @@
+# Template Resilience

--- a/internal/mcp/access_control.go
+++ b/internal/mcp/access_control.go
@@ -67,6 +67,9 @@ func buildPureTools() map[string]ToolClassification {
 		"render_template": {
 			PureCategory: CategoryRead,
 		},
+		"get_skill": {
+			PureCategory: CategoryRead,
+		},
 
 		// Pure write tools
 		"call_service": {

--- a/internal/mcp/access_control_test.go
+++ b/internal/mcp/access_control_test.go
@@ -52,6 +52,9 @@ func TestAccessControlMapCompleteness(t *testing.T) {
 		// Media and rendering
 		"render_template",
 		"validate_config",
+
+		// Skill guidance (tool-only client fallback)
+		"get_skill",
 	}
 
 	accessMap := buildAccessControlMap()
@@ -80,6 +83,7 @@ func TestPureReadTools(t *testing.T) {
 		"get_datetime",
 		"validate_config",
 		"render_template",
+		"get_skill",
 	}
 
 	for _, toolName := range pureReadTools {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -44,7 +44,9 @@ Useful patterns:
 - manage_script(action="get", format="json") to view full script config including sequence
 - query_entities(mode="health") to find stale, unavailable, or orphaned entities
 - query_devices(mode="health") to find disabled or orphaned devices
-- analyze_entity to trace entity usage across automations, scripts, and scenes`
+- analyze_entity to trace entity usage across automations, scripts, and scenes
+
+Guidance resources are available as skill:// MCP resources (use resources/list then resources/read with a skill://ha-mcp/<slug> URI) and via the get_skill tool (action=list to discover topics, action=read to fetch guidance).`
 
 // HTTP server timeout constants.
 const (


### PR DESCRIPTION
## Summary

- Adds 7 MCP resources under `skill://ha-mcp/<slug>` URI scheme: `format-selection`, `automation-patterns`, `template-resilience`, `helper-selection`, `dashboard-safety`, `entity-renaming`, `debugging-workflow`
- Content embedded via `//go:embed` — zero install required; ships inside the binary
- Adds `get_skill` tool (action=list/read, format=natural/json) as fallback for tool-only clients (claude.ai web)
- New `internal/handlers/skills/` package: `Catalog` slice + `Read(slug)` API
- 40 tools total (39 → 40); 7 MCP resources; no protocol changes (resource plumbing was already wired)
- `skill://` gap in `docs/feature-comparison.md` flipped ✗ → ✅

## Architecture

Single embedded source, two delivery channels: `skill://` resources for resource-aware clients (Claude Desktop, Cline); `get_skill` tool for tool-only clients (claude.ai web). Adding a skill = drop one `.md` file + add one `Catalog` entry.

## Test Plan

- [x] `task test` — all 10 packages green (new `internal/handlers/skills` package + 13 handler tests)
- [x] `task lint` — clean (pre-existing SA5011 not introduced by this PR)
- [x] `task build` — binary builds with embedded markdown
- [ ] `resources/list` JSON-RPC → returns 7 `skill://ha-mcp/*` resources
- [ ] `resources/read {"uri":"skill://ha-mcp/format-selection"}` → returns markdown body
- [ ] `get_skill {"action":"list"}` → lists 7 topics; `{"action":"read","skill":"automation-patterns"}` → returns content
- [ ] `--read-only` mode: server starts; `get_skill` accessible (classified `CategoryRead`)
- [ ] Startup log shows `Registered MCP resources count=7`

Closes #92