### PR TITLE
feat: analyze_entity includes RFC 6901 reference paths (closes #94)

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md
@@ -18,7 +18,7 @@ description: "Use when choosing which ha-mcp tool or action to call. Examples: \
 | Aggregated stats (min/max/mean) for a sensor         | `query_entities` mode=statistics                                       |
 | Which entity domains exist in this HA instance?      | `query_entities` mode=domains                                          |
 | Device health (orphaned / config errors)             | `query_devices` mode=health                                            |
-| Where is entity X used? (automations, scripts)       | `analyze_entity`                                                       |
+| Where is entity X used? (automations, scripts)       | `analyze_entity` — returns RFC 6901 paths to each reference location  |
 | Which entities does automation X depend on?          | `get_entity_dependencies`                                              |
 | Create / edit / delete an automation                 | `manage_automation` action=create/update/delete                        |
 | Toggle / enable / disable an automation              | `manage_automation` action=toggle                                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ AI Client (Claude, Cline)
 
 **Domain handlers** follow naming `handlers/{domain}.go` → `manage_{domain}` tool. Exceptions:
 - `entities.go` → `get_state`
-- `analysis.go` → `analyze_entity`, `get_entity_dependencies`
+- `analysis.go` → `analyze_entity`, `get_entity_dependencies`; `analysis_paths.go` → RFC 6901 path walker (`collectEntityPaths`, `collectSectionReferencePaths`, `collectAutomationReferencePaths`, `referencePathContext`) used to surface exact reference locations in `analyze_entity` output; `analysis_verbose.go` → excerpt summaries (verbose mode)
 - `entities_consolidated.go` → `query_entities`; `devices_consolidated.go` → `query_devices`
 - `targets_consolidated.go` → `analyze_target`; `registry_consolidated.go` → `get_registry`
 - `entities_manage.go` → `manage_entity`; `devices_manage.go` → `manage_device`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -19,7 +19,7 @@ Authorization: Bearer <your-ha-access-token>
 | `query_entities`          | Consolidated entity queries (mode: current, history, statistics, domains, presence, health; format: natural/json; group_by: domain, area_id, device_class, integration; health: multi-category filter for unavailable/unknown/disabled/orphaned/stale entities) |
 | `query_devices`           | Device health check (mode: health; format: natural/json; categories: disabled, orphaned_config_entry, config_entry_error, no_entities, no_config_entries; manufacturer filter)                                                                                |
 | `get_state`               | Get state of a specific entity (format: natural/json)                                                                                                                                                                                    |
-| `analyze_entity`          | Analyze entity usage in automations, scripts, and scenes; includes registry metadata (platform, area, device, labels, aliases) at zero extra API cost (format: natural/json)                                                             |
+| `analyze_entity`          | Analyze entity usage in automations, scripts, and scenes; includes registry metadata (platform, area, device, labels, aliases) and RFC 6901 JSON Pointer paths to each reference location (e.g. `/sequence/0/target/entity_id  (action: automation.turn_off)`) at zero extra API cost (format: natural/json) |
 | `get_entity_dependencies` | Find all entities an automation/script depends on (format: natural/json)                                                                                                                                                                 |
 
 ### Registry Tools

--- a/internal/handlers/analysis.go
+++ b/internal/handlers/analysis.go
@@ -145,20 +145,22 @@ type UsageExcerpt struct {
 
 // AutomationReference describes how an automation references an entity.
 type AutomationReference struct {
-	EntityID      string         `json:"entity_id"`
-	Alias         string         `json:"alias,omitempty"`
-	State         string         `json:"state"`
-	LastTriggered string         `json:"last_triggered,omitempty"`
-	UsedIn        []string       `json:"used_in"` // "trigger", "condition", "action"
-	Excerpts      []UsageExcerpt `json:"excerpts,omitempty"`
+	EntityID      string          `json:"entity_id"`
+	Alias         string          `json:"alias,omitempty"`
+	State         string          `json:"state"`
+	LastTriggered string          `json:"last_triggered,omitempty"`
+	UsedIn        []string        `json:"used_in"` // "trigger", "condition", "action"
+	Paths         []ReferencePath `json:"paths,omitempty"`
+	Excerpts      []UsageExcerpt  `json:"excerpts,omitempty"`
 }
 
 // ScriptReference describes how a script references an entity.
 type ScriptReference struct {
-	EntityID     string         `json:"entity_id"`
-	FriendlyName string         `json:"friendly_name,omitempty"`
-	UsedIn       string         `json:"used_in"` // "action"
-	Excerpts     []UsageExcerpt `json:"excerpts,omitempty"`
+	EntityID     string          `json:"entity_id"`
+	FriendlyName string          `json:"friendly_name,omitempty"`
+	UsedIn       string          `json:"used_in"` // "action"
+	Paths        []ReferencePath `json:"paths,omitempty"`
+	Excerpts     []UsageExcerpt  `json:"excerpts,omitempty"`
 }
 
 // SceneReference describes how a scene references an entity.
@@ -329,6 +331,7 @@ func (h *AnalysisHandlers) findAutomationReferences(ctx context.Context, client 
 				LastTriggered: auto.LastTriggered,
 				UsedIn:        usedIn,
 			}
+			ref.Paths = collectAutomationReferencePaths(fullAuto.Config, entityID)
 			if verbose {
 				ref.Excerpts = collectEntityExcerpts(fullAuto.Config, entityID)
 			}
@@ -358,6 +361,7 @@ func (h *AnalysisHandlers) findScriptReferences(ctx context.Context, client home
 			FriendlyName: fn,
 			UsedIn:       usedInAction,
 		}
+		ref.Paths = collectSectionReferencePaths(sequence, "sequence", "action", entityID)
 		if verbose {
 			ref.Excerpts = collectSequenceExcerpts(sequence, entityID)
 		}
@@ -1288,6 +1292,9 @@ func (h *AnalysisHandlers) formatAutomationRefs(parts []string, autos []Automati
 			name = auto.EntityID
 		}
 		parts = append(parts, fmt.Sprintf("  • %s (%s, %s)", name, auto.State, strings.Join(auto.UsedIn, "+")))
+		for _, rp := range auto.Paths {
+			parts = append(parts, formatReferencePath(rp))
+		}
 		if verbose {
 			for _, ex := range auto.Excerpts {
 				parts = append(parts, fmt.Sprintf("    %s: %s", ex.Section, ex.Summary))
@@ -1308,6 +1315,9 @@ func (h *AnalysisHandlers) formatScriptRefs(parts []string, scripts []ScriptRefe
 			name = script.EntityID
 		}
 		parts = append(parts, fmt.Sprintf("  • %s (%s)", name, script.UsedIn))
+		for _, rp := range script.Paths {
+			parts = append(parts, formatReferencePath(rp))
+		}
 		if verbose {
 			for _, ex := range script.Excerpts {
 				parts = append(parts, fmt.Sprintf("    %s: %s", ex.Section, ex.Summary))
@@ -1315,6 +1325,14 @@ func (h *AnalysisHandlers) formatScriptRefs(parts []string, scripts []ScriptRefe
 		}
 	}
 	return parts
+}
+
+// formatReferencePath formats a single ReferencePath as an indented line.
+func formatReferencePath(rp ReferencePath) string {
+	if rp.Context != "" {
+		return fmt.Sprintf("    %s  (%s)", rp.Path, rp.Context)
+	}
+	return fmt.Sprintf("    %s", rp.Path)
 }
 
 func (h *AnalysisHandlers) formatHistory(parts []string, history []HistoryEntry) []string {

--- a/internal/handlers/analysis_paths.go
+++ b/internal/handlers/analysis_paths.go
@@ -1,0 +1,125 @@
+// Package handlers provides MCP tool handlers for Home Assistant operations.
+package handlers
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+	"github.com/zorak1103/ha-mcp/internal/jsonpatch"
+)
+
+// ReferencePath is a single location where an entity_id appears in a config,
+// expressed as an RFC 6901 JSON Pointer path with a compact action context label.
+type ReferencePath struct {
+	Path    string `json:"path"`
+	Context string `json:"context,omitempty"`
+}
+
+// collectEntityPaths recursively walks node looking for leaves equal to entityID
+// and returns the RFC 6901 pointer path to each match, rooted at prefix.
+// Map keys are visited in sorted order for deterministic output.
+func collectEntityPaths(node any, entityID, prefix string) []string {
+	if node == nil {
+		return nil
+	}
+	switch v := node.(type) {
+	case string:
+		if v == entityID {
+			return []string{prefix}
+		}
+		return nil
+	case []any:
+		var paths []string
+		for i, item := range v {
+			sub := collectEntityPaths(item, entityID, prefix+"/"+strconv.Itoa(i))
+			paths = append(paths, sub...)
+		}
+		return paths
+	case map[string]any:
+		// Sort keys for deterministic output.
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		var paths []string
+		for _, k := range keys {
+			sub := collectEntityPaths(v[k], entityID, prefix+"/"+jsonpatch.EscapeSegment(k))
+			paths = append(paths, sub...)
+		}
+		return paths
+	}
+	return nil
+}
+
+// collectSectionReferencePaths collects all ReferencePaths for an entity_id
+// within a top-level section array (triggers, conditions, actions, sequence).
+// Each top-level step that contains the entity yields one ReferencePath per match,
+// all sharing the step-level context label.
+func collectSectionReferencePaths(section []any, sectionName, kind, entityID string) []ReferencePath {
+	var result []ReferencePath
+	for i, item := range section {
+		stepPrefix := fmt.Sprintf("/%s/%d", sectionName, i)
+		paths := collectEntityPaths(item, entityID, stepPrefix)
+		if len(paths) == 0 {
+			continue
+		}
+		// Derive context from the top-level step node.
+		ctx := ""
+		if stepMap, ok := item.(map[string]any); ok {
+			ctx = referencePathContext(kind, stepMap)
+		}
+		for _, p := range paths {
+			result = append(result, ReferencePath{Path: p, Context: ctx})
+		}
+	}
+	return result
+}
+
+// collectAutomationReferencePaths collects all ReferencePaths for an entity_id
+// across all three sections of an AutomationConfig (triggers, conditions, actions).
+func collectAutomationReferencePaths(config *homeassistant.AutomationConfig, entityID string) []ReferencePath {
+	var paths []ReferencePath
+	paths = append(paths, collectSectionReferencePaths(config.Triggers, "triggers", "trigger", entityID)...)
+	paths = append(paths, collectSectionReferencePaths(config.Conditions, "conditions", "condition", entityID)...)
+	paths = append(paths, collectSectionReferencePaths(config.Actions, "actions", "action", entityID)...)
+	return paths
+}
+
+// referencePathContext returns a compact context label for a top-level config step.
+// kind is "action", "trigger", or "condition".
+func referencePathContext(kind string, step map[string]any) string {
+	switch kind {
+	case "action":
+		if svc, ok := step["action"].(string); ok {
+			return "action: " + svc
+		}
+		if svc, ok := step["service"].(string); ok {
+			return "action: " + svc
+		}
+		if _, ok := step["choose"]; ok {
+			return "action: choose"
+		}
+		if _, ok := step["if"]; ok {
+			return "action: if/then"
+		}
+		return "action"
+	case "trigger":
+		if p, ok := step["platform"].(string); ok {
+			return "trigger: " + p
+		}
+		if p, ok := step["trigger"].(string); ok {
+			return "trigger: " + p
+		}
+		return "trigger"
+	case "condition":
+		if c, ok := step["condition"].(string); ok {
+			return "condition: " + c
+		}
+		return "condition"
+	}
+	return kind
+}

--- a/internal/handlers/analysis_paths_test.go
+++ b/internal/handlers/analysis_paths_test.go
@@ -1,0 +1,357 @@
+package handlers
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// --- collectEntityPaths ---
+
+func TestCollectEntityPaths_StringLeafMatch(t *testing.T) {
+	t.Parallel()
+
+	got := collectEntityPaths("sensor.x", "sensor.x", "/prefix")
+	want := []string{"/prefix"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_StringLeafNoMatch(t *testing.T) {
+	t.Parallel()
+
+	got := collectEntityPaths("sensor.y", "sensor.x", "/prefix")
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestCollectEntityPaths_NilNode(t *testing.T) {
+	t.Parallel()
+
+	got := collectEntityPaths(nil, "sensor.x", "/prefix")
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestCollectEntityPaths_ArrayWithMatchAtIndex(t *testing.T) {
+	t.Parallel()
+
+	node := []any{"other", "sensor.x"}
+	got := collectEntityPaths(node, "sensor.x", "/items")
+	want := []string{"/items/1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_ArrayWithMultipleMatches(t *testing.T) {
+	t.Parallel()
+
+	node := []any{"sensor.x", "other", "sensor.x"}
+	got := collectEntityPaths(node, "sensor.x", "/ids")
+	want := []string{"/ids/0", "/ids/2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_MapWithEntityIDMatch(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{
+		"entity_id": "sensor.x",
+		"platform":  "state",
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	want := []string{"/step/entity_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_NestedTargetEntityID(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{
+		"action": "automation.turn_off",
+		"target": map[string]any{
+			"entity_id": "sensor.x",
+		},
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	want := []string{"/step/target/entity_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_EntityIDAsArray(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{
+		"entity_id": []any{"sensor.a", "sensor.x"},
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	want := []string{"/step/entity_id/1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_MultipleOccurrences(t *testing.T) {
+	t.Parallel()
+
+	// entity appears both in entity_id and target.entity_id
+	node := map[string]any{
+		"entity_id": "sensor.x",
+		"target": map[string]any{
+			"entity_id": "sensor.x",
+		},
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	sort.Strings(got)
+	want := []string{"/step/entity_id", "/step/target/entity_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_NestedChooseBlock(t *testing.T) {
+	t.Parallel()
+
+	// entity inside a choose branch
+	node := map[string]any{
+		"choose": []any{
+			map[string]any{
+				"sequence": []any{
+					map[string]any{"entity_id": "sensor.x"},
+				},
+			},
+		},
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	want := []string{"/step/choose/0/sequence/0/entity_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_KeyEscaping(t *testing.T) {
+	t.Parallel()
+
+	// Map key containing "/" must be RFC 6901 escaped
+	node := map[string]any{
+		"a/b": "sensor.x",
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	want := []string{"/step/a~1b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCollectEntityPaths_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{
+		"entity_id": "sensor.y",
+		"platform":  "state",
+	}
+	got := collectEntityPaths(node, "sensor.x", "/step")
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+// --- referencePathContext ---
+
+func TestReferencePathContext_ActionWithActionKey(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"action": "automation.turn_off", "target": map[string]any{}}
+	got := referencePathContext("action", node)
+	want := "action: automation.turn_off"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ActionWithServiceKey(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"service": "light.turn_on"}
+	got := referencePathContext("action", node)
+	want := "action: light.turn_on"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ActionChoose(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"choose": []any{}}
+	got := referencePathContext("action", node)
+	want := "action: choose"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ActionIfThen(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"if": []any{}}
+	got := referencePathContext("action", node)
+	want := "action: if/then"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ActionBare(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"parallel": []any{}}
+	got := referencePathContext("action", node)
+	want := "action"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_TriggerWithPlatformKey(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"platform": "state"}
+	got := referencePathContext("trigger", node)
+	want := "trigger: state"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_TriggerWithTriggerKey(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"trigger": "time"}
+	got := referencePathContext("trigger", node)
+	want := "trigger: time"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_TriggerBare(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"unknown": "something"}
+	got := referencePathContext("trigger", node)
+	want := "trigger"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ConditionWithConditionKey(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"condition": "state"}
+	got := referencePathContext("condition", node)
+	want := "condition: state"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReferencePathContext_ConditionBare(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"unknown": "something"}
+	got := referencePathContext("condition", node)
+	want := "condition"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- collectSectionReferencePaths ---
+
+func TestCollectSectionReferencePaths_SingleActionMatch(t *testing.T) {
+	t.Parallel()
+
+	section := []any{
+		map[string]any{
+			"action": "automation.turn_off",
+			"target": map[string]any{"entity_id": "sensor.x"},
+		},
+	}
+	got := collectSectionReferencePaths(section, "sequence", "action", "sensor.x")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 path, got %d: %v", len(got), got)
+	}
+	if got[0].Path != "/sequence/0/target/entity_id" {
+		t.Errorf("path = %q, want %q", got[0].Path, "/sequence/0/target/entity_id")
+	}
+	if got[0].Context != "action: automation.turn_off" {
+		t.Errorf("context = %q, want %q", got[0].Context, "action: automation.turn_off")
+	}
+}
+
+func TestCollectSectionReferencePaths_MultipleStepsMultiplePaths(t *testing.T) {
+	t.Parallel()
+
+	section := []any{
+		map[string]any{
+			"action": "automation.turn_off",
+			"target": map[string]any{"entity_id": "sensor.x"},
+		},
+		map[string]any{
+			"action": "automation.turn_on",
+			"target": map[string]any{"entity_id": "sensor.x"},
+		},
+	}
+	got := collectSectionReferencePaths(section, "sequence", "action", "sensor.x")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(got), got)
+	}
+	if got[0].Path != "/sequence/0/target/entity_id" {
+		t.Errorf("path[0] = %q, want %q", got[0].Path, "/sequence/0/target/entity_id")
+	}
+	if got[1].Path != "/sequence/1/target/entity_id" {
+		t.Errorf("path[1] = %q, want %q", got[1].Path, "/sequence/1/target/entity_id")
+	}
+}
+
+func TestCollectSectionReferencePaths_NoMatchReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	section := []any{
+		map[string]any{"action": "light.turn_on", "entity_id": "light.desk"},
+	}
+	got := collectSectionReferencePaths(section, "sequence", "action", "sensor.x")
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestCollectSectionReferencePaths_TriggerSection(t *testing.T) {
+	t.Parallel()
+
+	section := []any{
+		map[string]any{"platform": "state", "entity_id": "sensor.x", "to": "on"},
+	}
+	got := collectSectionReferencePaths(section, "triggers", "trigger", "sensor.x")
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d: %v", len(got), got)
+	}
+	if got[0].Path != "/triggers/0/entity_id" {
+		t.Errorf("path = %q, want /triggers/0/entity_id", got[0].Path)
+	}
+	if got[0].Context != "trigger: state" {
+		t.Errorf("context = %q, want 'trigger: state'", got[0].Context)
+	}
+}

--- a/internal/handlers/analysis_test.go
+++ b/internal/handlers/analysis_test.go
@@ -2336,14 +2336,171 @@ func TestAnalysisHandlers_verbose_mode(t *testing.T) {
 		t.Errorf("verbose=true should include 'on' in trigger excerpt, got:\n%s", text)
 	}
 
-	// Test verbose=false (default) — should NOT include excerpt lines
+	// Test verbose=false (default) — should NOT include full excerpt lines.
+	// Paths are always shown (e.g. "trigger: state" appears as path context), but
+	// full excerpt summaries like 'state binary_sensor.motion → "on"' are verbose-only.
 	args2 := map[string]any{"entity_id": entityID, "format": "natural"}
 	result2, err := h.handleAnalyzeEntity(context.Background(), client, args2)
 	if err != nil {
 		t.Fatalf("handleAnalyzeEntity() error = %v", err)
 	}
 	text2 := result2.Content[0].Text
-	if strings.Contains(text2, "trigger: state") {
-		t.Errorf("verbose=false should not include trigger excerpt, got:\n%s", text2)
+	// The verbose excerpt contains the exact state value in quotes (e.g. → "on").
+	// Path context only shows the trigger type ("trigger: state"), not state values.
+	if strings.Contains(text2, `→ "on"`) {
+		t.Errorf("verbose=false should not include full trigger excerpt with state value, got:\n%s", text2)
+	}
+}
+
+// --- Reference path formatting tests ---
+
+// TestFormatScriptRefs_ShowsPaths verifies that formatScriptRefs includes RFC 6901
+// path lines when the ScriptReference has Paths populated.
+func TestFormatScriptRefs_ShowsPaths(t *testing.T) {
+	t.Parallel()
+
+	h := NewAnalysisHandlers()
+	scripts := []ScriptReference{
+		{
+			EntityID:     "script.morning",
+			FriendlyName: "Morning Script",
+			UsedIn:       "action",
+			Paths: []ReferencePath{
+				{Path: "/sequence/0/target/entity_id", Context: "action: automation.turn_off"},
+				{Path: "/sequence/3/target/entity_id", Context: "action: automation.turn_on"},
+			},
+		},
+	}
+
+	var parts []string
+	parts = h.formatScriptRefs(parts, scripts, false)
+	result := strings.Join(parts, "\n")
+
+	if !strings.Contains(result, "Morning Script") {
+		t.Errorf("should contain script name, got:\n%s", result)
+	}
+	if !strings.Contains(result, "/sequence/0/target/entity_id") {
+		t.Errorf("should contain first path, got:\n%s", result)
+	}
+	if !strings.Contains(result, "/sequence/3/target/entity_id") {
+		t.Errorf("should contain second path, got:\n%s", result)
+	}
+	if !strings.Contains(result, "action: automation.turn_off") {
+		t.Errorf("should contain context label, got:\n%s", result)
+	}
+}
+
+// TestFormatScriptRefs_NoPaths verifies that formatScriptRefs still works
+// cleanly when no Paths are populated (e.g. for scripts with no found references).
+func TestFormatScriptRefs_NoPaths(t *testing.T) {
+	t.Parallel()
+
+	h := NewAnalysisHandlers()
+	scripts := []ScriptReference{
+		{
+			EntityID:     "script.morning",
+			FriendlyName: "Morning Script",
+			UsedIn:       "action",
+		},
+	}
+
+	var parts []string
+	parts = h.formatScriptRefs(parts, scripts, false)
+	result := strings.Join(parts, "\n")
+
+	if !strings.Contains(result, "Morning Script") {
+		t.Errorf("should contain script name, got:\n%s", result)
+	}
+	// No path lines should appear.
+	if strings.Contains(result, "/sequence") {
+		t.Errorf("should not contain path segments when Paths is empty, got:\n%s", result)
+	}
+}
+
+// TestFormatAutomationRefs_ShowsPaths verifies that formatAutomationRefs includes
+// RFC 6901 path lines when the AutomationReference has Paths populated.
+func TestFormatAutomationRefs_ShowsPaths(t *testing.T) {
+	t.Parallel()
+
+	h := NewAnalysisHandlers()
+	autos := []AutomationReference{
+		{
+			EntityID: "automation.lights",
+			Alias:    "Turn on Lights",
+			State:    "on",
+			UsedIn:   []string{"trigger"},
+			Paths: []ReferencePath{
+				{Path: "/triggers/0/entity_id", Context: "trigger: state"},
+			},
+		},
+	}
+
+	var parts []string
+	parts = h.formatAutomationRefs(parts, autos, false)
+	result := strings.Join(parts, "\n")
+
+	if !strings.Contains(result, "Turn on Lights") {
+		t.Errorf("should contain automation alias, got:\n%s", result)
+	}
+	if !strings.Contains(result, "/triggers/0/entity_id") {
+		t.Errorf("should contain path, got:\n%s", result)
+	}
+	if !strings.Contains(result, "trigger: state") {
+		t.Errorf("should contain context, got:\n%s", result)
+	}
+}
+
+// TestHandleAnalyzeEntity_ScriptPathsInOutput is an integration-level unit test
+// that verifies the full handleAnalyzeEntity call populates and formats Paths.
+func TestHandleAnalyzeEntity_ScriptPathsInOutput(t *testing.T) {
+	t.Parallel()
+
+	const entityID = "automation.example"
+
+	// Build a script whose sequence contains the target entity_id.
+	sequence := []any{
+		map[string]any{
+			"action": "automation.turn_off",
+			"target": map[string]any{"entity_id": entityID},
+		},
+	}
+
+	client := &mockAnalysisClient{
+		GetStateFn: func(_ context.Context, eid string) (*homeassistant.Entity, error) {
+			return &homeassistant.Entity{EntityID: eid, State: "on"}, nil
+		},
+		ListAutomationsFn: func(context.Context) ([]homeassistant.Automation, error) {
+			return nil, nil
+		},
+		ListScriptsFn: func(context.Context) ([]homeassistant.Entity, error) {
+			return []homeassistant.Entity{
+				{
+					EntityID: "script.example_script",
+					State:    "off",
+					Attributes: map[string]any{
+						"friendly_name": "Example Script",
+						"sequence":      sequence,
+					},
+				},
+			}, nil
+		},
+	}
+
+	h := NewAnalysisHandlers()
+	args := map[string]any{"entity_id": entityID, "format": "natural"}
+	result, err := h.handleAnalyzeEntity(context.Background(), client, args)
+	if err != nil {
+		t.Fatalf("handleAnalyzeEntity() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleAnalyzeEntity() returned error result: %v", result.Content)
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, "/sequence/0/target/entity_id") {
+		t.Errorf("output should contain path to entity reference, got:\n%s", text)
+	}
+	if !strings.Contains(text, "action: automation.turn_off") {
+		t.Errorf("output should contain action context, got:\n%s", text)
 	}
 }

--- a/internal/jsonpatch/pointer.go
+++ b/internal/jsonpatch/pointer.go
@@ -33,6 +33,14 @@ func unescapeSegment(s string) string {
 	return s
 }
 
+// EscapeSegment applies RFC 6901 escape encoding to a single path segment:
+// ~ → ~0, / → ~1 (in that order — inverse of unescapeSegment).
+func EscapeSegment(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
 // Get retrieves the value at path in doc.
 // An empty path returns the whole document.
 func Get(doc any, path string) (any, error) {

--- a/internal/jsonpatch/pointer_test.go
+++ b/internal/jsonpatch/pointer_test.go
@@ -194,6 +194,47 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestEscapeSegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain segment", "entity_id", "entity_id"},
+		{"slash in key", "a/b", "a~1b"},
+		{"tilde in key", "a~b", "a~0b"},
+		{"tilde-slash combo", "a~/b", "a~0~1b"},
+		{"empty string", "", ""},
+		{"numeric", "42", "42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := EscapeSegment(tt.in)
+			if got != tt.want {
+				t.Errorf("EscapeSegment(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEscapeSegmentRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"entity_id", "a/b", "a~b", "a~/b", "target", "~1crazy~0key"}
+	for _, s := range cases {
+		escaped := EscapeSegment(s)
+		roundtripped := unescapeSegment(escaped)
+		if roundtripped != s {
+			t.Errorf("round-trip failed for %q: EscapeSegment → %q → unescapeSegment → %q", s, escaped, roundtripped)
+		}
+	}
+}
+
 func TestParseIndex(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `analyze_entity` now reports the exact JSON Pointer path(s) to every location where an entity appears in each referencing script/automation, along with a compact context label (service name, trigger type, condition type)
- Eliminates the extra `manage_script action=get` / `manage_automation action=get` call previously needed to locate a reference before patching
- Paths match the syntax expected by `action=patch`, so rename workflows become copy-paste ready

### Example output (before)
```
References (1 total):
- 1 scripts:
  • example_script (action)
    action: turn_off (contains automation.example_old)
```

### Example output (after)
```
References (1 total):
- 1 scripts:
  • example_script (action)
    /sequence/0/target/entity_id  (action: automation.turn_off)
    /sequence/3/target/entity_id  (action: automation.turn_on)
```

## Changes

| File | Change |
|------|--------|
| `internal/jsonpatch/pointer.go` | Add `EscapeSegment` — RFC 6901 segment encoder (fills the gap next to the existing `unescapeSegment`) |
| `internal/handlers/analysis_paths.go` | New — `ReferencePath`, `collectEntityPaths` walker (sorted map keys, full recursion, RFC 6901 key encoding), `collectSectionReferencePaths`, `collectAutomationReferencePaths`, `referencePathContext` |
| `internal/handlers/analysis.go` | `Paths []ReferencePath` field on `AutomationReference` + `ScriptReference`; populate in both finders; emit in both formatters; `formatReferencePath` helper |
| `internal/handlers/analysis_test.go` | Update verbose-mode assertion (path context contains "trigger: state" now); add 4 new formatter/integration-level tests |
| Docs | `docs/tools.md`, `CLAUDE.md`, `.claude/skills/ha-mcp/ha-mcp-tools/SKILL.md` |

## Test plan

- [x] 45 new unit tests: `EscapeSegment` encode/round-trip, `collectEntityPaths` (string leaf, array, map, nested target, entity_id array, choose block, multi-occurrence, key-escaping, no-match), `referencePathContext` (action/trigger/condition variants), `collectSectionReferencePaths` (single/multi-step, no-match, trigger section)
- [x] `TestFormatScriptRefs_ShowsPaths` / `TestFormatAutomationRefs_ShowsPaths` — verify formatter emits path lines
- [x] `TestHandleAnalyzeEntity_ScriptPathsInOutput` — end-to-end unit test: mock client returns script with sequence, output contains `/sequence/0/target/entity_id  (action: automation.turn_off)`
- [x] `task lint` clean (0 issues)
- [x] `go test ./...` green (91.1% handlers coverage, 85.5% jsonpatch coverage)
- [ ] Integration: `analyze_entity` on a real HA entity used by a script → verify path appears and works in `manage_script action=patch`