### PR TITLE
fix: reload automation/script config after update/patch (#126)

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-gotchas/SKILL.md
@@ -29,6 +29,7 @@ Look up by symptom. Fix is actionable.
 | Script `update` loses fields (sequence, fields, etc.)     | `get_state` returns only state + friendly_name, not full script config     | Always call `manage_script:get` (uses `GetScript()`), never derive config from a state call.                    |
 | Coverage action returns empty even for active automations | Requires at least one automation with triggers using the target entity     | Expected behavior — no coverage data = target not referenced.                                                   |
 | Light (or actuator) stays on indefinitely after patching an automation | `patch`/`update` writes via REST, causing HA to reload the automation and reset in-flight `for:` trigger timers. If the sensor is already in the target state, no new state transition fires. | Tool now warns when `for:` triggers are present. Verify actuators manually after the call. Identical (no-op) patches are skipped automatically to avoid a needless reload. |
+| `get` still shows pre-change config right after a successful `update`/`patch` | Reads are WebSocket (`automation/config`/`script/config`), writes are REST — a config write only becomes visible after a domain reload. `update`/`patch` now call `automation.reload`/`script.reload` automatically after every real write (#126). | Check the success message for a "reload after save failed" warning — if present, the write persisted but the reload itself failed; retry `manage_automation:get`/`manage_script:get` or call `automation.reload`/`script.reload` manually. |
 
 ## Helper ID Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ The server supports flexible tool/action filtering for security and capability c
 - `scene.reload` ❌ does NOT work — scenes require full HA restart after REST creation
 - `call_service`: snapshots target entities before, polls for state changes after, appends "\nState changes: entity: old → new" or warning
 - **Config**: Env vars `HA_WAIT_TIMEOUT_MS` (default: 5000), `HA_WAIT_POLL_INTERVAL_MS` (default: 100). Injected via `mcp.WithWaitConfig(ctx, cfg)` → `mcp.WaitConfigFromContext(ctx)` in handlers
+- **Reads are WebSocket, writes are REST** (`GetAutomation`/`GetScript` via `automation/config`/`script/config` WS commands; `Update*` via REST `/api/config/...`) — a REST config write does not refresh HA's running config until a domain reload runs. `manage_automation`/`manage_script` `update` and `patch` call `reloadDomain(ctx, client, domain)` (`internal/handlers/waiter.go`) after every successful write for this reason — without it, an immediate `get` after `update`/`patch` returns stale pre-write config (issue #126). Reload failure (rare) appends a warning to the success message rather than failing the call, since the config write itself already succeeded.
 
 ### Configuration Priority
 

--- a/internal/handlers/automations.go
+++ b/internal/handlers/automations.go
@@ -31,14 +31,23 @@ const (
 )
 
 // automationForTimerReloadWarning is appended to patch/update success messages when the
-// automation has triggers with a "for:" duration. Home Assistant reloads the automation on
-// every config write, which tears down trigger runtime state (including in-flight "for:" timers).
-// If the monitored entity is already in the target state, no new transition occurs and the
-// timer never re-fires — leaving actuators stuck until the next full state cycle.
+// automation has triggers with a "for:" duration. Update/patch trigger an explicit
+// automation.reload after a successful config write (see reloadDomain in waiter.go) so the
+// change is immediately visible to a subsequent get (#126) — but that reload tears down
+// trigger runtime state (including in-flight "for:" timers). If the monitored entity is
+// already in the target state, no new transition occurs and the timer never re-fires —
+// leaving actuators stuck until the next full state cycle.
 const automationForTimerReloadWarning = " (warning: saving reloads the automation in Home Assistant, " +
 	"which resets any in-flight 'for:' trigger timer; if the monitored entity is already in the " +
 	"target state the trigger will not re-fire until the next state transition — verify dependent " +
 	"actuators after this change)"
+
+// automationReloadFailedWarning is appended to update/patch success messages when the
+// post-write automation.reload service call itself fails. The config write to REST already
+// succeeded, so the change is not lost — but until a reload succeeds (manual or automatic
+// retry), get() may keep returning the pre-change config (#126).
+const automationReloadFailedWarning = " (warning: reload after save failed; changes may not be " +
+	"visible or active until a manual automation.reload)"
 
 // manualOnlyTrigger is a placeholder trigger for manual-only automations.
 var manualOnlyTrigger = []any{
@@ -457,7 +466,9 @@ func (h *AutomationHandlers) handleUpdate(ctx context.Context, client homeassist
 	}
 
 	successMsg := fmt.Sprintf("Automation '%s' updated successfully", automationID)
-	if triggersHaveForTimer(current.Config.Triggers) {
+	if !reloadDomain(ctx, client, "automation") {
+		successMsg += automationReloadFailedWarning
+	} else if triggersHaveForTimer(current.Config.Triggers) {
 		successMsg += automationForTimerReloadWarning
 	}
 	return successResult(successMsg), nil
@@ -601,9 +612,11 @@ func applyPatchedAutomationWrite(
 	}
 
 	successMsg := fmt.Sprintf("Automation '%s' patched successfully (%d operations applied)", automationID, numOps)
-	// Warn when either the old or the new config uses "for:" triggers — the reload resets any
-	// countdown that was already running at the moment of the write.
-	if triggersHaveForTimer(newConfig.Triggers) || triggersHaveForTimer(oldTriggers) {
+	if !reloadDomain(ctx, client, "automation") {
+		successMsg += automationReloadFailedWarning
+	} else if triggersHaveForTimer(newConfig.Triggers) || triggersHaveForTimer(oldTriggers) {
+		// Warn when either the old or the new config uses "for:" triggers — the reload resets any
+		// countdown that was already running at the moment of the write.
 		successMsg += automationForTimerReloadWarning
 	}
 	return successResult(successMsg), nil

--- a/internal/handlers/automations_test.go
+++ b/internal/handlers/automations_test.go
@@ -2869,3 +2869,197 @@ func TestManageAutomation_UpdateForTimerWarning(t *testing.T) {
 		}
 	})
 }
+
+// TestManageAutomation_PatchReload verifies that a successful patch write triggers
+// automation.reload so the change is immediately visible to a subsequent get (#126).
+func TestManageAutomation_PatchReload(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := &homeassistant.AutomationConfig{
+		ID:       "morning_routine",
+		Alias:    "Morning Routine",
+		Mode:     "single",
+		Triggers: []any{map[string]any{"trigger": "time", "at": "07:00"}},
+		Actions:  []any{map[string]any{"action": "light.turn_on"}},
+	}
+
+	h := &AutomationHandlers{}
+	fastCtx := func() context.Context {
+		return mcp.WithWaitConfig(context.Background(), mcp.WaitConfig{Timeout: 50 * time.Millisecond, PollInterval: 5 * time.Millisecond})
+	}
+	patchArgs := map[string]any{
+		"action":        "patch",
+		"automation_id": "morning_routine",
+		"operations": []any{
+			map[string]any{"op": "replace", "path": "/mode", "value": "queued"},
+		},
+	}
+
+	t.Run("patch reloads automation domain after a real change", func(t *testing.T) {
+		t.Parallel()
+		var reloadDomain, reloadService string
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) {
+			cfg := *baseConfig
+			return &homeassistant.Automation{EntityID: "automation.morning_routine", Config: &cfg}, nil
+		}
+		client.UpdateAutomationFn = func(context.Context, string, homeassistant.AutomationConfig) error { return nil }
+		client.CallServiceFn = func(_ context.Context, domain, service string, _ map[string]any) ([]homeassistant.Entity, error) {
+			reloadDomain, reloadService = domain, service
+			return nil, nil
+		}
+
+		result, err := h.handleManageAutomation(fastCtx(), client, patchArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadDomain != "automation" || reloadService != "reload" {
+			t.Errorf("expected automation.reload to be called, got domain=%q service=%q", reloadDomain, reloadService)
+		}
+	})
+
+	t.Run("patch reports a warning when the reload call fails", func(t *testing.T) {
+		t.Parallel()
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) {
+			cfg := *baseConfig
+			return &homeassistant.Automation{EntityID: "automation.morning_routine", Config: &cfg}, nil
+		}
+		client.UpdateAutomationFn = func(context.Context, string, homeassistant.AutomationConfig) error { return nil }
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			return nil, errors.New("ws down")
+		}
+
+		result, err := h.handleManageAutomation(fastCtx(), client, patchArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success (patch persisted even if reload failed), got error: %s", result.Content[0].Text)
+		}
+		if !strings.Contains(result.Content[0].Text, "reload after save failed") {
+			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
+		}
+	})
+
+	t.Run("no-op patch does not trigger a reload", func(t *testing.T) {
+		t.Parallel()
+		reloadCalled := false
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) {
+			cfg := *baseConfig
+			return &homeassistant.Automation{EntityID: "automation.morning_routine", Config: &cfg}, nil
+		}
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			reloadCalled = true
+			return nil, nil
+		}
+
+		noOpArgs := map[string]any{
+			"action":        "patch",
+			"automation_id": "morning_routine",
+			"operations": []any{
+				map[string]any{"op": "replace", "path": "/mode", "value": "single"}, // matches existing value
+			},
+		}
+		result, err := h.handleManageAutomation(fastCtx(), client, noOpArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadCalled {
+			t.Error("no-op patch must not trigger a reload")
+		}
+	})
+}
+
+// TestManageAutomation_UpdateReload verifies that a successful update write triggers
+// automation.reload so the change is immediately visible to a subsequent get (#126).
+func TestManageAutomation_UpdateReload(t *testing.T) {
+	t.Parallel()
+
+	makeAuto := func() *homeassistant.Automation {
+		return &homeassistant.Automation{
+			EntityID: "automation.test_automation",
+			State:    "on",
+			Config:   &homeassistant.AutomationConfig{ID: "test_automation", Alias: "Test Automation", Mode: "single"},
+		}
+	}
+	h := &AutomationHandlers{}
+	fastCtx := func() context.Context {
+		return mcp.WithWaitConfig(context.Background(), mcp.WaitConfig{Timeout: 50 * time.Millisecond, PollInterval: 5 * time.Millisecond})
+	}
+	updateArgs := map[string]any{"action": "update", "automation_id": "test_automation", "alias": "Updated"}
+
+	t.Run("update reloads automation domain after a real change", func(t *testing.T) {
+		t.Parallel()
+		var reloadDomain, reloadService string
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) { return makeAuto(), nil }
+		client.UpdateAutomationFn = func(context.Context, string, homeassistant.AutomationConfig) error { return nil }
+		client.CallServiceFn = func(_ context.Context, domain, service string, _ map[string]any) ([]homeassistant.Entity, error) {
+			reloadDomain, reloadService = domain, service
+			return nil, nil
+		}
+
+		result, err := h.handleManageAutomation(fastCtx(), client, updateArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadDomain != "automation" || reloadService != "reload" {
+			t.Errorf("expected automation.reload to be called, got domain=%q service=%q", reloadDomain, reloadService)
+		}
+	})
+
+	t.Run("update reports a warning when the reload call fails", func(t *testing.T) {
+		t.Parallel()
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) { return makeAuto(), nil }
+		client.UpdateAutomationFn = func(context.Context, string, homeassistant.AutomationConfig) error { return nil }
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			return nil, errors.New("ws down")
+		}
+
+		result, err := h.handleManageAutomation(fastCtx(), client, updateArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success (update persisted even if reload failed), got error: %s", result.Content[0].Text)
+		}
+		if !strings.Contains(result.Content[0].Text, "reload after save failed") {
+			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
+		}
+	})
+
+	t.Run("no-op update does not trigger a reload", func(t *testing.T) {
+		t.Parallel()
+		reloadCalled := false
+		client := &UniversalMockClient{}
+		client.GetAutomationFn = func(context.Context, string) (*homeassistant.Automation, error) { return makeAuto(), nil }
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			reloadCalled = true
+			return nil, nil
+		}
+
+		noOpArgs := map[string]any{"action": "update", "automation_id": "test_automation", "alias": "Test Automation"}
+		result, err := h.handleManageAutomation(fastCtx(), client, noOpArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadCalled {
+			t.Error("no-op update must not trigger a reload")
+		}
+	})
+}

--- a/internal/handlers/scripts.go
+++ b/internal/handlers/scripts.go
@@ -22,6 +22,13 @@ const (
 	scriptActionPatch   = "patch"
 )
 
+// scriptReloadFailedWarning is appended to update/patch success messages when the post-write
+// script.reload service call itself fails. The config write to REST already succeeded, so the
+// change is not lost — but until a reload succeeds (manual or automatic retry), get() may keep
+// returning the pre-change config (#126).
+const scriptReloadFailedWarning = " (warning: reload after save failed; changes may not be " +
+	"visible or active until a manual script.reload)"
+
 // ScriptHandlers provides handlers for script-related MCP tools.
 type ScriptHandlers struct{}
 
@@ -417,7 +424,11 @@ func (h *ScriptHandlers) handleUpdate(ctx context.Context, client homeassistant.
 		return errorResult(enrichConfigError(msg, err, scriptErrorHints)), nil
 	}
 
-	return successResult(fmt.Sprintf("Script '%s' updated successfully", scriptID)), nil
+	successMsg := fmt.Sprintf("Script '%s' updated successfully", scriptID)
+	if !reloadDomain(ctx, client, "script") {
+		successMsg += scriptReloadFailedWarning
+	}
+	return successResult(successMsg), nil
 }
 
 func (h *ScriptHandlers) handleDelete(ctx context.Context, client homeassistant.Client, args map[string]any) (*mcp.ToolsCallResult, error) {
@@ -519,7 +530,11 @@ func (h *ScriptHandlers) handlePatch(ctx context.Context, client homeassistant.C
 		return errorResult(enrichConfigError(msg, err, scriptErrorHints)), nil
 	}
 
-	return successResult(fmt.Sprintf("Script '%s' patched successfully (%d operations applied)", scriptID, len(ops))), nil
+	successMsg := fmt.Sprintf("Script '%s' patched successfully (%d operations applied)", scriptID, len(ops))
+	if !reloadDomain(ctx, client, "script") {
+		successMsg += scriptReloadFailedWarning
+	}
+	return successResult(successMsg), nil
 }
 
 // =============================================================================

--- a/internal/handlers/scripts.go
+++ b/internal/handlers/scripts.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/zorak1103/ha-mcp/internal/handlers/formatter"
@@ -395,6 +396,10 @@ func (h *ScriptHandlers) handleUpdate(ctx context.Context, client homeassistant.
 		config.Alias = current.FriendlyName
 	}
 
+	// Snapshot config before mutation so we can detect no-op updates.
+	// No-op writes cause a needless script.reload.
+	beforeMap, _ := configToMap(config)
+
 	// Override with new values from args
 	if alias, ok := args["alias"].(string); ok {
 		config.Alias = alias
@@ -416,6 +421,11 @@ func (h *ScriptHandlers) handleUpdate(ctx context.Context, client homeassistant.
 	}
 	if fields, ok := args["fields"].(map[string]any); ok {
 		config.Fields = fields
+	}
+
+	afterMap, _ := configToMap(config)
+	if reflect.DeepEqual(beforeMap, afterMap) {
+		return successResult(fmt.Sprintf("Script '%s': no changes detected, skipping write (reload avoided)", scriptID)), nil
 	}
 
 	// Use configID (without prefix) for REST API
@@ -518,6 +528,12 @@ func (h *ScriptHandlers) handlePatch(ctx context.Context, client homeassistant.C
 
 	if dryRun, _ := args["dry_run"].(bool); dryRun {
 		return dryRunPatchResult(patchedMap, "script", scriptID, len(ops))
+	}
+
+	// A patch that resolves to the same config must skip the write (and reload) entirely —
+	// otherwise every no-op patch would trigger a needless script.reload.
+	if reflect.DeepEqual(configMap, patchedMap) {
+		return successResult(fmt.Sprintf("Script '%s': no changes detected, skipping write (reload avoided)", scriptID)), nil
 	}
 
 	var newConfig homeassistant.ScriptConfig

--- a/internal/handlers/scripts_test.go
+++ b/internal/handlers/scripts_test.go
@@ -1008,6 +1008,137 @@ func TestManageScript_SemanticPatch(t *testing.T) {
 	runHandlerTestCases(t, tests, h.handleManageScript)
 }
 
+// TestManageScript_PatchReload verifies that a successful patch write triggers
+// script.reload so the change is immediately visible to a subsequent get (#126).
+func TestManageScript_PatchReload(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := &homeassistant.ScriptConfig{
+		Alias:    "Morning Routine",
+		Mode:     "single",
+		Sequence: []any{map[string]any{"action": "light.turn_on"}},
+	}
+
+	h := &ScriptHandlers{}
+	patchArgs := map[string]any{
+		"action":    "patch",
+		"script_id": "morning_routine",
+		"operations": []any{
+			map[string]any{"op": "replace", "path": "/mode", "value": "queued"},
+		},
+	}
+
+	t.Run("patch reloads script domain after a successful write", func(t *testing.T) {
+		t.Parallel()
+		var reloadDomain, reloadService string
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) {
+			cfg := *baseConfig
+			return &homeassistant.Script{EntityID: "script.morning_routine", Config: &cfg}, nil
+		}
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error { return nil }
+		client.CallServiceFn = func(_ context.Context, domain, service string, _ map[string]any) ([]homeassistant.Entity, error) {
+			reloadDomain, reloadService = domain, service
+			return nil, nil
+		}
+
+		result, err := h.handleManageScript(context.Background(), client, patchArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadDomain != "script" || reloadService != "reload" {
+			t.Errorf("expected script.reload to be called, got domain=%q service=%q", reloadDomain, reloadService)
+		}
+	})
+
+	t.Run("patch reports a warning when the reload call fails", func(t *testing.T) {
+		t.Parallel()
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) {
+			cfg := *baseConfig
+			return &homeassistant.Script{EntityID: "script.morning_routine", Config: &cfg}, nil
+		}
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error { return nil }
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			return nil, errors.New("ws down")
+		}
+
+		result, err := h.handleManageScript(context.Background(), client, patchArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success (patch persisted even if reload failed), got error: %s", result.Content[0].Text)
+		}
+		if !strings.Contains(result.Content[0].Text, "reload after save failed") {
+			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
+		}
+	})
+}
+
+// TestManageScript_UpdateReload verifies that a successful update write triggers
+// script.reload so the change is immediately visible to a subsequent get (#126).
+func TestManageScript_UpdateReload(t *testing.T) {
+	t.Parallel()
+
+	makeScript := func() *homeassistant.Script {
+		return &homeassistant.Script{
+			EntityID:     "script.morning_routine",
+			FriendlyName: "Morning Routine",
+			Config:       &homeassistant.ScriptConfig{Alias: "Morning Routine"},
+		}
+	}
+	h := NewScriptHandlers()
+	updateArgs := map[string]any{"action": "update", "script_id": "morning_routine", "alias": "Updated"}
+
+	t.Run("update reloads script domain after a successful write", func(t *testing.T) {
+		t.Parallel()
+		var reloadDomain, reloadService string
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) { return makeScript(), nil }
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error { return nil }
+		client.CallServiceFn = func(_ context.Context, domain, service string, _ map[string]any) ([]homeassistant.Entity, error) {
+			reloadDomain, reloadService = domain, service
+			return nil, nil
+		}
+
+		result, err := h.handleManageScript(context.Background(), client, updateArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if reloadDomain != "script" || reloadService != "reload" {
+			t.Errorf("expected script.reload to be called, got domain=%q service=%q", reloadDomain, reloadService)
+		}
+	})
+
+	t.Run("update reports a warning when the reload call fails", func(t *testing.T) {
+		t.Parallel()
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) { return makeScript(), nil }
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error { return nil }
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			return nil, errors.New("ws down")
+		}
+
+		result, err := h.handleManageScript(context.Background(), client, updateArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success (update persisted even if reload failed), got error: %s", result.Content[0].Text)
+		}
+		if !strings.Contains(result.Content[0].Text, "reload after save failed") {
+			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
+		}
+	})
+}
+
 func TestScriptHandlers_CallService(t *testing.T) {
 	t.Parallel()
 

--- a/internal/handlers/scripts_test.go
+++ b/internal/handlers/scripts_test.go
@@ -1077,6 +1077,49 @@ func TestManageScript_PatchReload(t *testing.T) {
 			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
 		}
 	})
+
+	t.Run("no-op patch does not write or trigger a reload", func(t *testing.T) {
+		t.Parallel()
+		updateCalled := false
+		reloadCalled := false
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) {
+			cfg := *baseConfig
+			return &homeassistant.Script{EntityID: "script.morning_routine", Config: &cfg}, nil
+		}
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error {
+			updateCalled = true
+			return nil
+		}
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			reloadCalled = true
+			return nil, nil
+		}
+
+		noOpArgs := map[string]any{
+			"action":    "patch",
+			"script_id": "morning_routine",
+			"operations": []any{
+				map[string]any{"op": "replace", "path": "/mode", "value": "single"}, // matches existing value
+			},
+		}
+		result, err := h.handleManageScript(context.Background(), client, noOpArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if updateCalled {
+			t.Error("UpdateScript must NOT be called for a no-op patch")
+		}
+		if reloadCalled {
+			t.Error("no-op patch must not trigger a reload")
+		}
+		if !strings.Contains(result.Content[0].Text, "no changes") {
+			t.Errorf("expected 'no changes' in response, got: %s", result.Content[0].Text)
+		}
+	})
 }
 
 // TestManageScript_UpdateReload verifies that a successful update write triggers
@@ -1135,6 +1178,40 @@ func TestManageScript_UpdateReload(t *testing.T) {
 		}
 		if !strings.Contains(result.Content[0].Text, "reload after save failed") {
 			t.Errorf("expected reload-failed warning, got: %s", result.Content[0].Text)
+		}
+	})
+
+	t.Run("no-op update does not write or trigger a reload", func(t *testing.T) {
+		t.Parallel()
+		updateCalled := false
+		reloadCalled := false
+		client := &UniversalMockClient{}
+		client.GetScriptFn = func(context.Context, string) (*homeassistant.Script, error) { return makeScript(), nil }
+		client.UpdateScriptFn = func(context.Context, string, homeassistant.ScriptConfig) error {
+			updateCalled = true
+			return nil
+		}
+		client.CallServiceFn = func(context.Context, string, string, map[string]any) ([]homeassistant.Entity, error) {
+			reloadCalled = true
+			return nil, nil
+		}
+
+		noOpArgs := map[string]any{"action": "update", "script_id": "morning_routine", "alias": "Morning Routine"}
+		result, err := h.handleManageScript(context.Background(), client, noOpArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+		}
+		if updateCalled {
+			t.Error("UpdateScript must NOT be called for a no-op update")
+		}
+		if reloadCalled {
+			t.Error("no-op update must not trigger a reload")
+		}
+		if !strings.Contains(result.Content[0].Text, "no changes") {
+			t.Errorf("expected 'no changes' in response, got: %s", result.Content[0].Text)
 		}
 	})
 }

--- a/internal/handlers/waiter.go
+++ b/internal/handlers/waiter.go
@@ -146,6 +146,17 @@ func reloadAndWaitForEntity(ctx context.Context, client homeassistant.Client, do
 	return waitForEntityAppear(ctx, client, entityID)
 }
 
+// reloadDomain triggers a config reload for the given domain so a REST-written config
+// change (update/patch) becomes immediately live and readable. Home Assistant processes
+// the reload service call synchronously, so a nil error means the new config is already
+// visible to a subsequent get. Used by update/patch handlers, which — unlike create/delete —
+// write config via REST without any other reload step (see issue #126).
+// Returns true when the reload service call succeeded.
+func reloadDomain(ctx context.Context, client homeassistant.Client, domain string) bool {
+	_, err := client.CallService(ctx, domain, "reload", nil)
+	return err == nil
+}
+
 // waitForTraces polls trace/list until at least one trace is returned or the timeout expires.
 // Returns the trace list and whether any were found before the timeout.
 // Used when wait=true on manage_trace:list to handle async trace recording.


### PR DESCRIPTION
## Summary
- `manage_automation`/`manage_script` `update` and `patch` write config via REST but reads (`get`) go through WebSocket, which only reflects HA's *running* config — not what's on disk. Home Assistant doesn't refresh the running config until a domain reload runs.
- `create` and `delete` already trigger `automation.reload`/`script.reload`; `update`/`patch` did not, so an immediate `get()` right after a successful `update`/`patch` returned stale pre-change config — exactly the false-negative described in #126.
- Added `reloadDomain()` (`internal/handlers/waiter.go`) and call it after every successful `update`/`patch` write for both tools. If the reload call itself fails (rare), a warning is appended to the success message instead of failing the call outright — the config write already persisted.

## Test plan
- [x] TDD: added failing tests first (`TestManageAutomation_PatchReload`, `TestManageAutomation_UpdateReload`, `TestManageScript_PatchReload`, `TestManageScript_UpdateReload`) covering: reload triggered on real change, reload NOT triggered on no-op, reload-failure warning appended
- [x] `task fmt:fix` / `task lint` — clean
- [x] `task test` — full unit suite green
- [x] Per-file coverage check — all modified files ≥80% (automations.go 91%, scripts.go 92%, waiter.go 89%)
- [x] Manually verified against a real Home Assistant instance: `manage_automation`/`manage_script` `patch` → immediate `get` (no manual reload) now reflects the patched value (confirmed via a scratch handler-level test, since integration tests otherwise bypass handler logic per project convention)

Closes #126