### PR TITLE
fix: clarify JSON Patch errors and docs for nested if/then/else paths

### DIFF
--- a/.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md
+++ b/.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md
@@ -62,6 +62,28 @@ Use when array indexes are unreliable — re-ordered, unknown position, or after
 ]
 ```
 
+## Nested Action Structures
+
+`section` in Semantic Ops only addresses **top-level** arrays (`triggers`, `conditions`,
+`actions`, …). Editing inside a `choose`/`if`/`repeat` action block requires a standard
+`path` op that descends into the nested structure — and the nesting is easy to get wrong:
+
+| Block    | Structure                                                        | Example path                       |
+| -------- | ----------------------------------------------------------------- | ----------------------------------- |
+| `choose` | `conditions`/`sequence` are children **inside each choose option** | `/actions/0/choose/0/sequence/-`   |
+| `choose` | `default` is a **sibling of `choose`**, not inside an option       | `/actions/0/default/-`             |
+| `if`     | `then`/`else` are **siblings of `if`**, NOT nested inside it       | `/actions/0/then/-`, `/actions/0/else/-` |
+| `repeat` | `sequence` is a child of `repeat`                                  | `/actions/0/repeat/sequence/-`     |
+
+<EXTREMELY-IMPORTANT>
+`then`/`else` are siblings of `if` at the same level — they are NOT inside the `if` array.
+`/actions/0/if/0/then/0` is wrong (issue #124); the correct path is `/actions/0/then/0`.
+</EXTREMELY-IMPORTANT>
+
+If a path op fails with "key not found", the error now reports the prefix it actually
+navigated (not your full submitted path) plus a hint when the missing key is one of
+`then`/`else`/`sequence`/`default` — use that prefix + `get` output to find the right sibling.
+
 ## Worked Snippets
 
 **Replace automation mode:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,8 @@ Tool actions and parameters are defined in the handler schemas. Non-obvious aspe
 - Supported ops: `add`, `remove`, `replace`, `test` (standard: also `move`, `copy`)
 - Atomic: if any operation fails, the config is not modified
 - Standard paths use RFC 6901 JSON Pointer syntax: `/triggers/0/entity_id`, `/actions/-` (append)
-- Implemented in `internal/jsonpatch/` (RFC 6902 engine) + `internal/handlers/patch_semantic.go` (semantic layer)
+- **Nested action blocks (issue #124):** `then`/`else` are siblings of `if`, NOT nested inside it — `/actions/0/then/0`, not `/actions/0/if/0/then/0`. `choose` nests `conditions`/`sequence` per option (`/actions/0/choose/0/sequence/-`); `default` is a sibling of `choose` (`/actions/0/default/-`). `section` in semantic ops only addresses top-level arrays — nested blocks require standard `path` ops. See `.claude/skills/ha-mcp/ha-mcp-patching/SKILL.md` ("Nested Action Structures").
+- Implemented in `internal/jsonpatch/` (RFC 6902 engine) + `internal/handlers/patch_semantic.go` (semantic layer). A `key not found` error reports the prefix actually navigated (not the full submitted path) plus a structural hint for `then`/`else`/`sequence`/`default` misses (`internal/jsonpatch/pointer.go`: `navigatedPrefix`, `actionBlockKeyHint`, `keyNotFoundError`)
 
 **Access Control & Tool Filtering:**
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,6 +63,12 @@ Authorization: Bearer <your-ha-access-token>
 - `field`: field within matched element(s) to modify (omit for `remove` to delete the whole element)
 - `match_index`: optional 0-based index to select a specific match when multiple elements match
 
+`section` only addresses **top-level** arrays. Editing inside a nested `choose`/`if`/`repeat`
+action block requires a standard JSON Pointer `path` op instead — and the nesting is easy to
+get wrong: `then`/`else` are **siblings of `if`**, not nested inside it. Use
+`/actions/0/then/0`, not `/actions/0/if/0/then/0`. See the `ha-mcp-patching` skill
+("Nested Action Structures") for the full `choose`/`if`/`repeat` path reference.
+
 **Key Parameters (create/update):**
 
 | Parameter    | Type    | Required | Description                                                                                     |

--- a/internal/jsonpatch/apply.go
+++ b/internal/jsonpatch/apply.go
@@ -220,7 +220,7 @@ func setInMap(d map[string]any, seg string, rest []string, value any, insert boo
 	}
 	child, ok := d[seg]
 	if !ok {
-		return nil, fmt.Errorf("key %q not found at path %q (available keys: %v)", seg, path, sortedMapKeys(d))
+		return nil, keyNotFoundError(seg, path, rest, sortedMapKeys(d))
 	}
 	newChild, err := setAtPath(child, rest, value, insert, path)
 	if err != nil {
@@ -294,7 +294,7 @@ func removeAtPath(doc any, segs []string, path string) (any, error) {
 // removeFromMap handles removing from a map.
 func removeFromMap(d map[string]any, seg string, rest []string, path string) (any, error) {
 	if _, ok := d[seg]; !ok {
-		return nil, fmt.Errorf("key %q not found at path %q (available keys: %v)", seg, path, sortedMapKeys(d))
+		return nil, keyNotFoundError(seg, path, rest, sortedMapKeys(d))
 	}
 	if len(rest) == 0 {
 		delete(d, seg)

--- a/internal/jsonpatch/apply_test.go
+++ b/internal/jsonpatch/apply_test.go
@@ -559,6 +559,110 @@ func TestApply_ErrorMessages(t *testing.T) {
 	}
 }
 
+// TestApply_NestedErrorMessages covers issue #124: a missing key deep inside a
+// nested action structure (if/then/else, choose/sequence/default) should report
+// the prefix actually navigated (not the full submitted path) plus a structural
+// hint when the missing key is one of these HA action-block keywords.
+func TestApply_NestedErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		docJSON   string
+		op        Operation
+		wantMsg   []string
+		wantNoMsg []string
+	}{
+		{
+			name:    "add: nested miss reports parent prefix, not full path",
+			docJSON: `{"a":{"b":{"if":[]}}}`,
+			op:      Operation{Op: "add", Path: "/a/b/then/0", Value: 1},
+			wantMsg: []string{`at "/a/b"`, "available keys: [if]"},
+		},
+		{
+			name:    "add: then hint when then is missing sibling of if",
+			docJSON: `{"actions":[{"if":[{"condition":"state"}],"then":[]}]}`,
+			op:      Operation{Op: "add", Path: "/actions/0/if/0/then/0", Value: map[string]any{}},
+			wantMsg: []string{"sibling", `"if"`},
+		},
+		{
+			name:    "add: else hint when else is missing sibling of if",
+			docJSON: `{"actions":[{"if":[{"condition":"state"}],"else":[]}]}`,
+			op:      Operation{Op: "add", Path: "/actions/0/if/0/else/0", Value: map[string]any{}},
+			wantMsg: []string{"sibling", `"if"`},
+		},
+		{
+			name:    "add: sequence hint when sequence is missing inside conditions",
+			docJSON: `{"actions":[{"choose":[{"conditions":[{"condition":"state"}],"sequence":[]}]}]}`,
+			op:      Operation{Op: "add", Path: "/actions/0/choose/0/conditions/0/sequence/0", Value: map[string]any{}},
+			wantMsg: []string{`"choose"`, `"repeat"`},
+		},
+		{
+			name:    "add: default hint when default is missing inside choose",
+			docJSON: `{"actions":[{"choose":[{"conditions":[],"sequence":[]}],"default":[]}]}`,
+			op:      Operation{Op: "add", Path: "/actions/0/choose/0/default/0", Value: map[string]any{}},
+			wantMsg: []string{"sibling", `"choose"`},
+		},
+		{
+			name:      "add: non-keyword miss has no structural hint",
+			docJSON:   `{"actions":[{"choose":[]}]}`,
+			op:        Operation{Op: "add", Path: "/actions/0/notarealkey/x", Value: 1},
+			wantMsg:   []string{`"notarealkey"`},
+			wantNoMsg: []string{"sibling", "nested inside"},
+		},
+		{
+			name:    "remove: nested miss reports parent prefix",
+			docJSON: `{"a":{"b":{"if":[]}}}`,
+			op:      Operation{Op: "remove", Path: "/a/b/then"},
+			wantMsg: []string{`at "/a/b"`, "available keys: [if]"},
+		},
+		{
+			name:    "remove: then hint when then is missing sibling of if",
+			docJSON: `{"actions":[{"if":[{"condition":"state"}]}]}`,
+			op:      Operation{Op: "remove", Path: "/actions/0/if/0/then"},
+			wantMsg: []string{"sibling", `"if"`},
+		},
+		{
+			name:    "replace: nested miss reports parent prefix",
+			docJSON: `{"a":{"b":{"if":[]}}}`,
+			op:      Operation{Op: "replace", Path: "/a/b/then", Value: 1},
+			wantMsg: []string{`at "/a/b"`, "available keys: [if]"},
+		},
+		{
+			name:    "add: escaped segment prefix round-trips",
+			docJSON: `{"weird~key":{"child":{"if":[]}}}`,
+			op:      Operation{Op: "add", Path: "/weird~0key/child/then/0", Value: 1},
+			wantMsg: []string{`at "/weird~0key/child"`, "available keys: [if]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var doc any
+			if err := json.Unmarshal([]byte(tt.docJSON), &doc); err != nil {
+				t.Fatalf("invalid test doc JSON: %v", err)
+			}
+
+			_, err := Apply(doc, []Operation{tt.op})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			for _, want := range tt.wantMsg {
+				if !containsStr(err.Error(), want) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), want)
+				}
+			}
+			for _, notWant := range tt.wantNoMsg {
+				if containsStr(err.Error(), notWant) {
+					t.Errorf("error = %q, want NOT to contain %q", err.Error(), notWant)
+				}
+			}
+		})
+	}
+}
+
 func TestApply_EdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/jsonpatch/apply_test.go
+++ b/internal/jsonpatch/apply_test.go
@@ -535,6 +535,11 @@ func TestApply_ErrorMessages(t *testing.T) {
 			errMsg: "available keys: [items mode]",
 		},
 		{
+			name:   "root-level miss still echoes the requested path",
+			ops:    []Operation{{Op: "replace", Path: "/notexist", Value: "x"}},
+			errMsg: `document root (requested "/notexist")`,
+		},
+		{
 			name:   "test failure includes expected and actual",
 			ops:    []Operation{{Op: "test", Path: "/mode", Value: "queued"}},
 			errMsg: "test failed",

--- a/internal/jsonpatch/pointer.go
+++ b/internal/jsonpatch/pointer.go
@@ -64,7 +64,7 @@ func getAtSegs(doc any, segs []string, origPath string) (any, error) {
 	case map[string]any:
 		val, ok := d[seg]
 		if !ok {
-			return nil, fmt.Errorf("key %q not found at path %q (available keys: %v)", seg, origPath, sortedMapKeys(d))
+			return nil, keyNotFoundError(seg, origPath, rest, sortedMapKeys(d))
 		}
 		return getAtSegs(val, rest, origPath)
 	case []any:
@@ -111,4 +111,59 @@ func sortedMapKeys(m map[string]any) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// navigatedPrefix reconstructs the JSON Pointer prefix successfully navigated
+// before a failing segment. fullPath is the original operation path (unchanged
+// throughout recursion); rest is the tail of segments still remaining after the
+// failing segment. Returns "" when the failure occurred on the first segment
+// (i.e. at the document root).
+func navigatedPrefix(fullPath string, rest []string) string {
+	segs, err := Segments(fullPath)
+	if err != nil {
+		return fullPath
+	}
+	consumed := len(segs) - len(rest) - 1
+	if consumed <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, s := range segs[:consumed] {
+		b.WriteByte('/')
+		b.WriteString(EscapeSegment(s))
+	}
+	return b.String()
+}
+
+// actionBlockKeyHint returns structural guidance for Home Assistant action-block
+// keywords that are commonly mistaken for children of a sibling key (issue #124).
+// Returns "" for keys with no known structural gotcha.
+func actionBlockKeyHint(key string) string {
+	switch key {
+	case "then", "else":
+		return `"then" and "else" are siblings of "if" at the same level, not nested inside the "if" array (e.g. /actions/0/then/0)`
+	case "sequence":
+		return `"sequence" is nested inside each "choose" option or inside "repeat", not at this level (e.g. /actions/0/choose/0/sequence/0)`
+	case "default":
+		return `"default" is a sibling of "choose" at the same level, not nested inside it (e.g. /actions/0/default/0)`
+	default:
+		return ""
+	}
+}
+
+// keyNotFoundError builds the "key not found" error for map navigation failures,
+// reporting the prefix actually navigated (not the full submitted path) and
+// appending a structural hint when the missing key is a commonly-confused
+// Home Assistant action-block keyword (see actionBlockKeyHint).
+func keyNotFoundError(seg, fullPath string, rest, available []string) error {
+	loc := navigatedPrefix(fullPath, rest)
+	locDesc := "document root"
+	if loc != "" {
+		locDesc = fmt.Sprintf("%q", loc)
+	}
+	err := fmt.Errorf("key %q not found at %s (available keys: %v)", seg, locDesc, available)
+	if hint := actionBlockKeyHint(seg); hint != "" {
+		err = fmt.Errorf("%w; %s", err, hint)
+	}
+	return err
 }

--- a/internal/jsonpatch/pointer.go
+++ b/internal/jsonpatch/pointer.go
@@ -137,7 +137,9 @@ func navigatedPrefix(fullPath string, rest []string) string {
 
 // actionBlockKeyHint returns structural guidance for Home Assistant action-block
 // keywords that are commonly mistaken for children of a sibling key (issue #124).
-// Returns "" for keys with no known structural gotcha.
+// Returns "" for keys with no known structural gotcha. This is a heuristic keyed
+// only on the missing segment name — it assumes an HA automation/script document
+// and may fire on an unrelated schema that happens to reuse one of these key names.
 func actionBlockKeyHint(key string) string {
 	switch key {
 	case "then", "else":
@@ -157,7 +159,7 @@ func actionBlockKeyHint(key string) string {
 // Home Assistant action-block keyword (see actionBlockKeyHint).
 func keyNotFoundError(seg, fullPath string, rest, available []string) error {
 	loc := navigatedPrefix(fullPath, rest)
-	locDesc := "document root"
+	locDesc := fmt.Sprintf("document root (requested %q)", fullPath)
 	if loc != "" {
 		locDesc = fmt.Sprintf("%q", loc)
 	}

--- a/internal/jsonpatch/pointer_test.go
+++ b/internal/jsonpatch/pointer_test.go
@@ -149,6 +149,12 @@ func TestGet(t *testing.T) {
 			wantErrMsg: "available keys: [mode nested triggers]",
 		},
 		{
+			name:       "nested miss reports parent prefix, not full path",
+			path:       "/nested/notexist",
+			wantErr:    true,
+			wantErrMsg: `at "/nested" (available keys: [deep])`,
+		},
+		{
 			name:    "index out of bounds",
 			path:    "/triggers/5",
 			wantErr: true,
@@ -262,6 +268,108 @@ func TestParseIndex(t *testing.T) {
 			}
 			if !tt.wantErr && got != tt.want {
 				t.Errorf("parseIndex(%q, %d) = %d, want %d", tt.seg, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGet_ActionBlockHints covers issue #124: users assume then/else/sequence/default
+// nest one level deeper than they actually do (e.g. inside "if" rather than as its
+// sibling). A missing-key error for one of these keywords should include a structural
+// hint; a miss on an unrelated key should not.
+func TestGet_ActionBlockHints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		doc       map[string]any
+		path      string
+		wantMsg   []string
+		wantNoMsg []string
+	}{
+		{
+			name: "then is sibling of if, not nested inside it",
+			doc: map[string]any{
+				"actions": []any{
+					map[string]any{
+						"if":   []any{map[string]any{"condition": "state"}},
+						"then": []any{},
+					},
+				},
+			},
+			path:    "/actions/0/if/0/then",
+			wantMsg: []string{"sibling", `"if"`},
+		},
+		{
+			name: "else is sibling of if, not nested inside it",
+			doc: map[string]any{
+				"actions": []any{
+					map[string]any{
+						"if":   []any{map[string]any{"condition": "state"}},
+						"else": []any{},
+					},
+				},
+			},
+			path:    "/actions/0/if/0/else",
+			wantMsg: []string{"sibling", `"if"`},
+		},
+		{
+			name: "sequence lives inside choose/repeat, not inside conditions",
+			doc: map[string]any{
+				"actions": []any{
+					map[string]any{
+						"choose": []any{
+							map[string]any{
+								"conditions": []any{map[string]any{"condition": "state"}},
+								"sequence":   []any{},
+							},
+						},
+					},
+				},
+			},
+			path:    "/actions/0/choose/0/conditions/0/sequence",
+			wantMsg: []string{`"choose"`, `"repeat"`},
+		},
+		{
+			name: "default is sibling of choose, not nested inside it",
+			doc: map[string]any{
+				"actions": []any{
+					map[string]any{
+						"choose":  []any{map[string]any{"conditions": []any{}, "sequence": []any{}}},
+						"default": []any{},
+					},
+				},
+			},
+			path:    "/actions/0/choose/0/default",
+			wantMsg: []string{"sibling", `"choose"`},
+		},
+		{
+			name: "non-keyword miss has no structural hint",
+			doc: map[string]any{
+				"actions": []any{map[string]any{"choose": []any{}}},
+			},
+			path:      "/actions/0/notarealkey",
+			wantNoMsg: []string{"sibling", "nested inside"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Get(tt.doc, tt.path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			for _, want := range tt.wantMsg {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), want)
+				}
+			}
+			for _, notWant := range tt.wantNoMsg {
+				if strings.Contains(err.Error(), notWant) {
+					t.Errorf("error = %q, want NOT to contain %q", err.Error(), notWant)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Enhance `internal/jsonpatch` "key not found" errors to report the prefix actually navigated (not the full submitted path) and append a structural hint when the missing key is `then`/`else`/`sequence`/`default` — the HA action-block keywords users most often nest incorrectly (e.g. `/actions/0/if/0/then/0` instead of the correct `/actions/0/then/0`)
- Document `choose`/`if`/`repeat` nesting rules in the `ha-mcp-patching` skill, `CLAUDE.md`, and `docs/tools.md`

## Test plan
- [x] `task test` — full unit suite passes, including new TDD coverage in `internal/jsonpatch/{apply,pointer}_test.go` for add/remove/replace, root-level misses, escaped-segment prefixes, and each action-block hint (positive + negative cases)
- [x] `task lint` — 0 issues
- [x] `task fmt:fix` — clean
- [x] Roborev review addressed (root-level path echo preserved per feedback; heuristic scope documented)

Fixes #124