### PR TITLE
fix: actionable hint for Jinja2 TemplateSyntaxError in config errors

### DIFF
--- a/internal/handlers/automations_test.go
+++ b/internal/handlers/automations_test.go
@@ -2390,11 +2390,12 @@ func TestFetchAutomationConfigs(t *testing.T) {
 
 func TestEnrichAutomationError(t *testing.T) {
 	tests := []struct {
-		name        string
-		msg         string
-		err         error
-		wantContain string
-		wantExact   string
+		name           string
+		msg            string
+		err            error
+		wantContain    string
+		wantNotContain string
+		wantExact      string
 	}{
 		{
 			name:      "non-API error unchanged",
@@ -2446,13 +2447,26 @@ func TestEnrichAutomationError(t *testing.T) {
 			wantContain: "domain.service",
 		},
 		{
-			name: "invalid template triggers hint",
+			// Real-world message from issue #55: TemplateSyntaxError must match the specific
+			// rule (before the generic "invalid template" rule), even though the body contains
+			// both substrings.
+			name: "template syntax error triggers specific split-expression hint",
+			msg:  "error saving patched automation: HA error",
+			err: &homeassistant.APIError{
+				StatusCode: 400,
+				Message:    "invalid automation config: {\"message\":\"Message malformed: invalid template (TemplateSyntaxError: unexpected '}') for dictionary value @ data['conditions'][1]['value_template']\"}",
+			},
+			wantContain: "{% set %}",
+		},
+		{
+			name: "invalid template triggers generic hint",
 			msg:  "Error updating automation: HA error",
 			err: &homeassistant.APIError{
 				StatusCode: 400,
 				Message:    "invalid automation config: {\"message\":\"invalid template\"}",
 			},
-			wantContain: "Jinja2",
+			wantContain:    "Jinja2",
+			wantNotContain: "{% set %}",
 		},
 		{
 			name: "unrecognized 400 error unchanged",
@@ -2477,6 +2491,11 @@ func TestEnrichAutomationError(t *testing.T) {
 			if tt.wantContain != "" {
 				if !strings.Contains(result, tt.wantContain) {
 					t.Errorf("expected result to contain %q, got %q", tt.wantContain, result)
+				}
+			}
+			if tt.wantNotContain != "" {
+				if strings.Contains(result, tt.wantNotContain) {
+					t.Errorf("expected result to NOT contain %q, got %q", tt.wantNotContain, result)
 				}
 			}
 		})

--- a/internal/handlers/error_enrichment.go
+++ b/internal/handlers/error_enrichment.go
@@ -55,6 +55,15 @@ var automationErrorHints = []configErrorHint{
 		suggestion: "The service name in 'action' may be wrong. Use 'domain.service' format, e.g. 'light.turn_on', 'notify.mobile_app'. Check available services with call_service tool.",
 	},
 	{
+		// Specific match before the generic "invalid template" catch-all below.
+		pattern: "templatesyntaxerror",
+		suggestion: "Jinja2 template syntax error. If the expression is complex, split it into " +
+			"multiple '{% set %}' lines and keep the final '{{ ... }}' simple — chaining filters " +
+			"(e.g. from_json) with and/or in one block often trips the parser. Example: " +
+			"{% set days = states('input_text.x') %}{% set empty = days in ['unknown','unavailable',''] %}{{ empty }}. " +
+			"The data[...] path shown in the error above identifies which template failed.",
+	},
+	{
 		pattern:    "invalid template",
 		suggestion: "Template syntax error. HA uses Jinja2: {{ states('sensor.x') }}, {{ is_state('entity', 'on') }}, etc.",
 	},
@@ -68,6 +77,15 @@ var scriptErrorHints = []configErrorHint{
 	{
 		pattern:    "required key not provided",
 		suggestion: "A required field is missing from the script config. Each sequence step needs an 'action' key.",
+	},
+	{
+		// Specific match before the generic "invalid template" catch-all below.
+		pattern: "templatesyntaxerror",
+		suggestion: "Jinja2 template syntax error in script. If the expression is complex, split it into " +
+			"multiple '{% set %}' lines and keep the final '{{ ... }}' simple — chaining filters " +
+			"(e.g. from_json) with and/or in one block often trips the parser. Example: " +
+			"{% set days = states('input_text.x') %}{% set empty = days in ['unknown','unavailable',''] %}{{ empty }}. " +
+			"The data[...] path shown in the error above identifies which template failed.",
 	},
 	{
 		pattern:    "invalid template",

--- a/internal/handlers/error_enrichment.go
+++ b/internal/handlers/error_enrichment.go
@@ -32,6 +32,17 @@ func enrichConfigError(msg string, err error, hints []configErrorHint) string {
 
 //nolint:gochecknoglobals // static lookup tables for error enrichment
 
+// templateSyntaxErrorHint is shared by automation and script hint tables.
+const templateSyntaxErrorHint = "Jinja2 template syntax error. \"unexpected '}'\" " +
+	"(or similar) usually means an unbalanced brace — check that every '{{' has a " +
+	"matching '}}' and every '{%' a matching '%}', and look for a stray or missing " +
+	"brace. If the braces are balanced, the expression may be too complex for one " +
+	"block: split it into multiple '{% set %}' lines and keep the final '{{ ... }}' " +
+	"simple (chaining filters like from_json with and/or in one block can also trip " +
+	"the parser). Example: {% set days = states('input_text.x') %}" +
+	"{% set empty = days in ['unknown','unavailable',''] %}{{ empty }}. " +
+	"The data[...] path shown in the error above identifies which template failed."
+
 var automationErrorHints = []configErrorHint{
 	{
 		// Specific match before the generic "extra keys not allowed" catch-all.
@@ -56,12 +67,8 @@ var automationErrorHints = []configErrorHint{
 	},
 	{
 		// Specific match before the generic "invalid template" catch-all below.
-		pattern: "templatesyntaxerror",
-		suggestion: "Jinja2 template syntax error. If the expression is complex, split it into " +
-			"multiple '{% set %}' lines and keep the final '{{ ... }}' simple — chaining filters " +
-			"(e.g. from_json) with and/or in one block often trips the parser. Example: " +
-			"{% set days = states('input_text.x') %}{% set empty = days in ['unknown','unavailable',''] %}{{ empty }}. " +
-			"The data[...] path shown in the error above identifies which template failed.",
+		pattern:    "templatesyntaxerror",
+		suggestion: templateSyntaxErrorHint,
 	},
 	{
 		pattern:    "invalid template",
@@ -80,12 +87,8 @@ var scriptErrorHints = []configErrorHint{
 	},
 	{
 		// Specific match before the generic "invalid template" catch-all below.
-		pattern: "templatesyntaxerror",
-		suggestion: "Jinja2 template syntax error in script. If the expression is complex, split it into " +
-			"multiple '{% set %}' lines and keep the final '{{ ... }}' simple — chaining filters " +
-			"(e.g. from_json) with and/or in one block often trips the parser. Example: " +
-			"{% set days = states('input_text.x') %}{% set empty = days in ['unknown','unavailable',''] %}{{ empty }}. " +
-			"The data[...] path shown in the error above identifies which template failed.",
+		pattern:    "templatesyntaxerror",
+		suggestion: templateSyntaxErrorHint,
 	},
 	{
 		pattern:    "invalid template",

--- a/internal/handlers/error_enrichment_test.go
+++ b/internal/handlers/error_enrichment_test.go
@@ -1,0 +1,52 @@
+// Package handlers provides MCP tool handlers for Home Assistant operations.
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
+)
+
+func TestEnrichConfigError_ScriptTemplateSyntaxError(t *testing.T) {
+	tests := []struct {
+		name           string
+		msg            string
+		err            error
+		wantContain    string
+		wantNotContain string
+	}{
+		{
+			name: "template syntax error triggers specific split-expression hint",
+			msg:  "Error updating script: HA error",
+			err: &homeassistant.APIError{
+				StatusCode: 400,
+				Message:    "invalid script config: {\"message\":\"Message malformed: invalid template (TemplateSyntaxError: unexpected '}') for dictionary value @ data['sequence'][0]['data']['message']\"}",
+			},
+			wantContain: "{% set %}",
+		},
+		{
+			name: "generic invalid template still falls back",
+			msg:  "Error updating script: HA error",
+			err: &homeassistant.APIError{
+				StatusCode: 400,
+				Message:    "invalid script config: {\"message\":\"invalid template\"}",
+			},
+			wantContain:    "Jinja2",
+			wantNotContain: "{% set %}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := enrichConfigError(tt.msg, tt.err, scriptErrorHints)
+
+			if tt.wantContain != "" && !strings.Contains(result, tt.wantContain) {
+				t.Errorf("expected result to contain %q, got %q", tt.wantContain, result)
+			}
+			if tt.wantNotContain != "" && strings.Contains(result, tt.wantNotContain) {
+				t.Errorf("expected result to NOT contain %q, got %q", tt.wantNotContain, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- HA's `TemplateSyntaxError` (e.g. `unexpected '}'`) errors previously only got the generic "HA uses Jinja2" hint, which restated that Jinja2 exists without helping identify the actual cause (see follow-up comment on #55).
- Adds a more specific `templatesyntaxerror` hint to `automationErrorHints` and `scriptErrorHints`, ordered before the existing generic `invalid template` catch-all (first-match-wins), suggesting to split complex `{{ }}` expressions into multiple `{% set %}` lines — the fix confirmed to work in the reported case.
- No changes to `sceneErrorHints` (scenes have no template fields) or to the schema/description-based approach — this follows the same Option B (error enrichment) direction already established for this repo.

Closes #55

## Test plan
- [x] `go test ./internal/handlers -run 'TestEnrichAutomationError|TestEnrichConfigError_ScriptTemplateSyntaxError' -v` — new/updated cases pass, including the real-world message from the issue and a fallback case proving the generic hint still applies to non-syntax template errors
- [x] `task test` — full suite green
- [x] `task lint` — 0 issues
- [x] `gofmt -l` — clean