### PR TITLE
fix: show entity ID in manage_script list output

### DIFF
--- a/internal/handlers/formatter/scripts.go
+++ b/internal/handlers/formatter/scripts.go
@@ -186,16 +186,21 @@ func (f *NaturalScriptFormatter) formatModeCounts(counts map[string]int) string 
 	return strings.Join(parts, ", ")
 }
 
+// scriptObjectID returns the bare object_id (entity_id without the "script." prefix).
+func scriptObjectID(script homeassistant.Script) string {
+	return strings.TrimPrefix(script.EntityID, "script.")
+}
+
 func (f *NaturalScriptFormatter) getDisplayName(script homeassistant.Script) string {
 	if script.FriendlyName != "" {
 		return script.FriendlyName
 	}
-	return strings.TrimPrefix(script.EntityID, "script.")
+	return scriptObjectID(script)
 }
 
 func (f *NaturalScriptFormatter) writeScriptLine(result *strings.Builder, script homeassistant.Script, verbose bool) {
 	name := f.getDisplayName(script)
-	scriptID := strings.TrimPrefix(script.EntityID, "script.")
+	scriptID := scriptObjectID(script)
 
 	stepCount := 0
 	if script.Config != nil {

--- a/internal/handlers/formatter/scripts.go
+++ b/internal/handlers/formatter/scripts.go
@@ -195,13 +195,14 @@ func (f *NaturalScriptFormatter) getDisplayName(script homeassistant.Script) str
 
 func (f *NaturalScriptFormatter) writeScriptLine(result *strings.Builder, script homeassistant.Script, verbose bool) {
 	name := f.getDisplayName(script)
+	scriptID := strings.TrimPrefix(script.EntityID, "script.")
 
 	stepCount := 0
 	if script.Config != nil {
 		stepCount = len(script.Config.Sequence)
 	}
 
-	fmt.Fprintf(result, "- %s", name)
+	fmt.Fprintf(result, "- %s [%s]", name, scriptID)
 
 	// Add step count
 	if stepCount > 0 {

--- a/internal/handlers/formatter/scripts_test.go
+++ b/internal/handlers/formatter/scripts_test.go
@@ -66,6 +66,57 @@ func TestNaturalScriptFormatter_FormatList(t *testing.T) {
 	if !strings.Contains(result, "Morning Routine") {
 		t.Errorf("expected 'Morning Routine' in output, got: %s", result)
 	}
+
+	// Verify bare entity IDs are shown so entities sharing a display name
+	// (e.g. an orphan "_2" duplicate) remain distinguishable (issue #122)
+	for _, wantID := range []string{"[morning_routine]", "[bedtime]", "[quick_clean]"} {
+		if !strings.Contains(result, wantID) {
+			t.Errorf("expected %q in output, got: %s", wantID, result)
+		}
+	}
+}
+
+func TestNaturalScriptFormatter_FormatList_DistinguishesDuplicateAlias(t *testing.T) {
+	ctx := context.Background()
+	f := NewNaturalScriptFormatter()
+
+	// Regression test for issue #122: an orphan "_2" duplicate entity
+	// (created by the now-fixed write-path bug) shares its FriendlyName
+	// with the original script. The list output must still let a reader
+	// tell them apart via entity ID.
+	scripts := []homeassistant.Script{
+		{
+			EntityID:      "script.boiler_off",
+			State:         "off",
+			FriendlyName:  "Boiler Off",
+			LastTriggered: time.Now().Add(-21 * time.Hour).Format(time.RFC3339),
+			Config: &homeassistant.ScriptConfig{
+				Mode:     "single",
+				Sequence: []any{map[string]any{"service": "switch.turn_off"}},
+			},
+		},
+		{
+			EntityID:     "script.boiler_off_2",
+			State:        "off",
+			FriendlyName: "Boiler Off",
+			Config: &homeassistant.ScriptConfig{
+				Mode:     "single",
+				Sequence: []any{map[string]any{"service": "switch.turn_off"}},
+			},
+		},
+	}
+
+	result, err := f.FormatList(ctx, scripts, ScriptListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "[boiler_off]") {
+		t.Errorf("expected '[boiler_off]' in output, got: %s", result)
+	}
+	if !strings.Contains(result, "[boiler_off_2]") {
+		t.Errorf("expected '[boiler_off_2]' in output, got: %s", result)
+	}
 }
 
 func TestNaturalScriptFormatter_FormatList_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary
- `manage_script(action="list")`'s natural-format output now prints each script's bare entity ID (e.g. `[boiler_off]`) next to its name, matching `manage_automation`'s existing list format.
- Closes the observability gap behind the reopened #122: an orphan `_2` duplicate entity (left over from the now-fixed #130 write-path bug) previously rendered identically to the original script in list output, since only `format=json` carried `entity_id`.
- No changes to the write-path guard (`yaml_defined.go`), `format=json` output, or `manage_scene`'s formatter (same gap there, but out of scope for this issue).

## Test plan
- [x] `go test ./internal/handlers/formatter/...` — new/updated `TestNaturalScriptFormatter_FormatList` and `TestNaturalScriptFormatter_FormatList_DistinguishesDuplicateAlias` pass.
- [x] `task test` — full suite passes.
- [x] `task lint` — clean (`0 issues.`).
- [ ] `roborev wait` — not run: `roborev` is not installed/available in this environment (no binary on PATH, no post-commit hook configured in this worktree).

Closes #122