### PR TITLE
fix: resolve trace item_id to unique_id instead of passing entity_id

### DIFF
--- a/internal/handlers/traces.go
+++ b/internal/handlers/traces.go
@@ -110,9 +110,10 @@ func (h *TraceHandlers) HandleManageTrace(ctx context.Context, client homeassist
 	}
 }
 
-// resolveTraceListParams derives domain and item_id from entity_id (when provided),
+// resolveTraceListParams derives domain and the entity_id from entity_id (when provided),
 // validates the prefix, and checks for conflicts with an explicit domain parameter.
-func resolveTraceListParams(entityID, domain string) (resolvedDomain, itemID, errMsg string) {
+// The returned entityID must still be mapped to HA's trace item_id via resolveTraceItemID.
+func resolveTraceListParams(entityID, domain string) (resolvedDomain, resolvedEntityID, errMsg string) {
 	if entityID == "" {
 		return domain, "", ""
 	}
@@ -130,13 +131,45 @@ func resolveTraceListParams(entityID, domain string) (resolvedDomain, itemID, er
 	return derived, entityID, ""
 }
 
+// resolveTraceItemID maps an entity_id to the item_id Home Assistant's trace API expects.
+// HA stores traces under the key "<domain>.<item_id>", where item_id is the object's
+// unique_id, NOT its entity_id:
+//   - Scripts: unique_id is the config key. It matches the entity's object_id unless the
+//     entity was renamed after creation, so it is resolved via the entity registry and
+//     degrades to the object_id on lookup failure. Passing the full entity_id produces
+//     the nonexistent key "script.script.<id>".
+//   - Automations: unique_id is the automation's config id, which differs from the
+//     entity object_id for UI-created automations, so it is resolved via GetAutomation.
+//     On lookup failure it degrades to the object_id.
+func resolveTraceItemID(ctx context.Context, client homeassistant.Client, domain, entityID string) string {
+	objectID := entityID
+	if dotIdx := strings.Index(entityID, "."); dotIdx >= 0 {
+		objectID = entityID[dotIdx+1:]
+	}
+	switch domain {
+	case traceDomainAutomation:
+		if auto, err := client.GetAutomation(ctx, entityID); err == nil && auto.Config != nil && auto.Config.ID != "" {
+			return auto.Config.ID
+		}
+	case traceDomainScript:
+		if entries, err := client.GetEntityRegistry(ctx); err == nil {
+			for _, entry := range entries {
+				if entry.EntityID == entityID && entry.UniqueID != "" {
+					return entry.UniqueID
+				}
+			}
+		}
+	}
+	return objectID
+}
+
 // handleListTraces lists all traces for a domain.
 func (h *TraceHandlers) handleListTraces(ctx context.Context, client homeassistant.Client, args map[string]any, format string) (*mcp.ToolsCallResult, error) {
 	domain, _ := args["domain"].(string)
 	entityID, _ := args["entity_id"].(string)
 	wait, _ := args["wait"].(bool)
 
-	domain, itemID, errMsg := resolveTraceListParams(entityID, domain)
+	domain, traceEntityID, errMsg := resolveTraceListParams(entityID, domain)
 	if errMsg != "" {
 		return errorResult(errMsg), nil
 	}
@@ -147,8 +180,8 @@ func (h *TraceHandlers) handleListTraces(ctx context.Context, client homeassista
 	// Build command data
 	data := make(map[string]any)
 	data["domain"] = domain
-	if itemID != "" {
-		data["item_id"] = itemID
+	if traceEntityID != "" {
+		data["item_id"] = resolveTraceItemID(ctx, client, domain, traceEntityID)
 	}
 
 	// Call trace/list WebSocket command
@@ -229,7 +262,7 @@ func (h *TraceHandlers) handleGetTrace(ctx context.Context, client homeassistant
 	// Build command data
 	data := map[string]any{
 		"domain":  domain,
-		"item_id": entityID,
+		"item_id": resolveTraceItemID(ctx, client, domain, entityID),
 		"run_id":  runID,
 	}
 

--- a/internal/handlers/traces.go
+++ b/internal/handlers/traces.go
@@ -347,8 +347,22 @@ func (h *TraceHandlers) formatTraceNatural(response any) string {
 
 		if actions, ok := trace["actions"].([]any); ok {
 			parts = append(parts, fmt.Sprintf("\nActions: %d executed", len(actions)))
+		} else if steps := countPrefixedKeys(trace, "sequence/"); steps > 0 {
+			// Script traces store executed steps under "sequence/<n>" keys.
+			parts = append(parts, fmt.Sprintf("\nSequence steps: %d executed", steps))
 		}
 	}
 
 	return strings.Join(parts, "\n")
+}
+
+// countPrefixedKeys returns the number of map keys starting with prefix.
+func countPrefixedKeys(m map[string]any, prefix string) int {
+	n := 0
+	for k := range m {
+		if strings.HasPrefix(k, prefix) {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/handlers/traces_debug.go
+++ b/internal/handlers/traces_debug.go
@@ -165,7 +165,7 @@ func fetchDebugAutomationConfig(ctx context.Context, client homeassistant.Client
 func (h *TraceHandlers) fetchLatestTrace(ctx context.Context, client homeassistant.Client, entityID string) *AutomationDebugTrace {
 	data := map[string]any{
 		"domain":  traceDomainAutomation,
-		"item_id": entityID,
+		"item_id": resolveTraceItemID(ctx, client, traceDomainAutomation, entityID),
 	}
 	response, err := client.SendHACSCommand(ctx, "trace/list", data)
 	if err != nil {

--- a/internal/handlers/traces_test.go
+++ b/internal/handlers/traces_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zorak1103/ha-mcp/internal/homeassistant"
 	"github.com/zorak1103/ha-mcp/internal/mcp"
 )
 
@@ -222,12 +223,18 @@ func TestManageTrace_Get(t *testing.T) {
 	t.Parallel()
 
 	client := &UniversalMockClient{
+		GetAutomationFn: func(_ context.Context, automationID string) (*homeassistant.Automation, error) {
+			return &homeassistant.Automation{
+				EntityID: "automation.test",
+				Config:   &homeassistant.AutomationConfig{ID: "1700000000001"},
+			}, nil
+		},
 		SendHACSCommandFn: func(_ context.Context, cmd string, data map[string]any) (any, error) {
 			if cmd != "trace/get" {
 				t.Errorf("cmd = %q, want %q", cmd, "trace/get")
 			}
-			if data["item_id"] != "automation.test" {
-				t.Errorf("data[item_id] = %v, want %q", data["item_id"], "automation.test")
+			if data["item_id"] != "1700000000001" {
+				t.Errorf("data[item_id] = %v, want %q", data["item_id"], "1700000000001")
 			}
 			if _, exists := data["entity_id"]; exists {
 				t.Errorf("data should not contain entity_id (found: %v)", data["entity_id"])
@@ -282,13 +289,13 @@ func TestManageTrace_List_EntityIDFilter(t *testing.T) {
 			name:       "entity_id automation prefix derives domain and item_id",
 			args:       map[string]any{"action": "list", "entity_id": "automation.ev_charging"},
 			wantDomain: "automation",
-			wantItemID: "automation.ev_charging",
+			wantItemID: "ev_charging",
 		},
 		{
 			name:       "entity_id script prefix derives domain and item_id",
 			args:       map[string]any{"action": "list", "entity_id": "script.morning_routine"},
 			wantDomain: "script",
-			wantItemID: "script.morning_routine",
+			wantItemID: "morning_routine",
 		},
 		{
 			name:        "entity_id conflicts with explicit domain",
@@ -343,6 +350,78 @@ func TestManageTrace_List_EntityIDFilter(t *testing.T) {
 			}
 			if capturedData["item_id"] != tt.wantItemID {
 				t.Errorf("data[item_id] = %v, want %q", capturedData["item_id"], tt.wantItemID)
+			}
+		})
+	}
+}
+
+// TestResolveTraceItemID verifies entity_id → trace item_id mapping:
+// scripts resolve via the entity registry unique_id (renamed entities keep their
+// original unique_id, which is what HA keys traces by), automations via the config ID.
+func TestResolveTraceItemID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		domain   string
+		entityID string
+		registry []homeassistant.EntityRegistryEntry
+		auto     *homeassistant.Automation
+		wantItem string
+	}{
+		{
+			name:     "script uses registry unique_id when entity was renamed",
+			domain:   "script",
+			entityID: "script.bedtime",
+			registry: []homeassistant.EntityRegistryEntry{
+				{EntityID: "script.bedtime", UniqueID: "labeled_feature_sleep_timeout"},
+			},
+			wantItem: "labeled_feature_sleep_timeout",
+		},
+		{
+			name:     "script falls back to object_id when registry lookup misses",
+			domain:   "script",
+			entityID: "script.morning_routine",
+			wantItem: "morning_routine",
+		},
+		{
+			name:     "automation uses config ID",
+			domain:   "automation",
+			entityID: "automation.ev_charging",
+			auto: &homeassistant.Automation{
+				EntityID: "automation.ev_charging",
+				Config:   &homeassistant.AutomationConfig{ID: "1700000000001"},
+			},
+			wantItem: "1700000000001",
+		},
+		{
+			name:     "automation falls back to object_id when config has no ID",
+			domain:   "automation",
+			entityID: "automation.ev_charging",
+			auto:     &homeassistant.Automation{EntityID: "automation.ev_charging"},
+			wantItem: "ev_charging",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &UniversalMockClient{
+				GetEntityRegistryFn: func(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+					return tt.registry, nil
+				},
+				GetAutomationFn: func(context.Context, string) (*homeassistant.Automation, error) {
+					if tt.auto != nil {
+						return tt.auto, nil
+					}
+					return &homeassistant.Automation{}, nil
+				},
+			}
+
+			got := resolveTraceItemID(context.Background(), client, tt.domain, tt.entityID)
+			if got != tt.wantItem {
+				t.Errorf("resolveTraceItemID() = %q, want %q", got, tt.wantItem)
 			}
 		})
 	}


### PR DESCRIPTION
Had issues pulling traces from scripts, so pointed my AI at this repo and found the root issue. Built locally and tested. Happy to make changes if you need.

## Summary

- `manage_trace` passed the full `entity_id` (e.g. `script.labeled_feature_sleep_timeout`) as `item_id` to the `trace/list` and `trace/get` WebSocket commands. Home Assistant builds its trace lookup key as `f"{domain}.{item_id}"` (`homeassistant/components/trace/websocket_api.py`), so every entity-filtered trace query looked up a nonexistent key like `script.script.labeled_feature_sleep_timeout` — `list`/`get` always returned empty, and the `debug` report's "Latest Trace" section was always blank.
- HA keys traces by the object's **unique_id**, not its entity_id: scripts via `trace_script(hass, self._attr_unique_id, ...)` (config key = object_id unless the entity was renamed), automations via the config `id` (differs from the entity slug for UI-created automations).
- Added `resolveTraceItemID()` (`internal/handlers/traces.go`): scripts resolve the unique_id via the entity registry (falling back to the object_id on lookup failure), automations via `GetAutomation` → `Config.ID` (same fallback). Wired into all three call sites: `handleListTraces`, `handleGetTrace`, and the debug report's `fetchLatestTrace`.
- `manage_trace get`'s natural formatter only understood automation-shaped traces (`actions` key), so script traces rendered an empty "Trace Execution Path:" header even when data was returned. It now renders `Sequence steps: N executed` from the `sequence/<n>` step keys.

No issue filed — happy to open one first if you prefer the paper trail.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `go vet ./internal/handlers/` — clean
- [x] Updated `TestManageTrace_Get` / `TestManageTrace_List_EntityIDFilter` (both previously asserted the buggy full-entity_id `item_id`)
- [x] New `TestResolveTraceItemID`: script registry-unique_id resolution (renamed entity), script object_id fallback, automation config-ID resolution, automation object_id fallback
- [x] Live verification against a real Home Assistant (deployed via a branch-built image to a toolhive-managed MCPServer):
  - `manage_trace list` for `script.labeled_feature_sleep_timeout`: 0 traces before → 5 traces after
  - `manage_trace get` for one of those run_ids: full 59 KB trace returned, natural format shows `Sequence steps: 50 executed`
  - `manage_trace debug` for an automation: "Latest Trace" section populated (run ID, state, trigger description) — previously always empty


## Follow-ups (out of scope)

- `internal/handlers/integration/traces_integration_test.go` mirrors the old bug: it passes `item_id: entityID` directly and asserts only "no error", never that traces are returned — which is why this shipped. Hardening it to assert non-empty filtered results through the tool dispatch would let a live-HA integration run catch this class of regression.