### PR TITLE
refactor: modernize sort.Slice usage and snapshot concurrency

### DIFF
--- a/internal/handlers/analysis.go
+++ b/internal/handlers/analysis.go
@@ -2,9 +2,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -841,8 +843,8 @@ func (h *AnalysisHandlers) dependenciesToSortedSlice(seen map[string]DependencyE
 	for _, dep := range seen {
 		result = append(result, dep)
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].EntityID < result[j].EntityID
+	slices.SortFunc(result, func(a, b DependencyEntry) int {
+		return cmp.Compare(a.EntityID, b.EntityID)
 	})
 	return result
 }

--- a/internal/handlers/analysis_snapshot.go
+++ b/internal/handlers/analysis_snapshot.go
@@ -28,53 +28,30 @@ type AnalysisSnapshot struct {
 // CreateAnalysisSnapshot fetches all data needed for entity analysis in parallel.
 // This optimizes analysis by making 4 parallel API calls instead of multiple sequential calls.
 // Returns a snapshot even if some fetches fail - the caller should check individual fields.
-//
-//nolint:funlen // Parallel fetch structure is clear and readable despite statement count.
 func CreateAnalysisSnapshot(ctx context.Context, client homeassistant.Client) *AnalysisSnapshot {
 	snapshot := &AnalysisSnapshot{}
 
 	var wg sync.WaitGroup
-	var mu sync.Mutex
 
 	// Fetch all states
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		states, _ := client.GetStates(ctx)
-		mu.Lock()
-		snapshot.AllStates = states
-		mu.Unlock()
-	}()
+	wg.Go(func() {
+		snapshot.AllStates, _ = client.GetStates(ctx)
+	})
 
 	// Fetch entity registry
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		entities, _ := client.GetEntityRegistry(ctx)
-		mu.Lock()
-		snapshot.EntityRegistry = entities
-		mu.Unlock()
-	}()
+	wg.Go(func() {
+		snapshot.EntityRegistry, _ = client.GetEntityRegistry(ctx)
+	})
 
 	// Fetch device registry
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		devices, _ := client.GetDeviceRegistry(ctx)
-		mu.Lock()
-		snapshot.DeviceRegistry = devices
-		mu.Unlock()
-	}()
+	wg.Go(func() {
+		snapshot.DeviceRegistry, _ = client.GetDeviceRegistry(ctx)
+	})
 
 	// Fetch area registry
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		areas, _ := client.GetAreaRegistry(ctx)
-		mu.Lock()
-		snapshot.AreaRegistry = areas
-		mu.Unlock()
-	}()
+	wg.Go(func() {
+		snapshot.AreaRegistry, _ = client.GetAreaRegistry(ctx)
+	})
 
 	wg.Wait()
 	return snapshot

--- a/internal/handlers/areas.go
+++ b/internal/handlers/areas.go
@@ -2,8 +2,10 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -474,6 +476,7 @@ func (h *AreaHandlers) countDevicesInArea(ctx context.Context, client homeassist
 }
 
 // collectAreaEntities returns compact entity states for all entities in the area, sorted by entity_id.
+// collectAreaEntities returns compact entity states for all entities in the area, sorted by entity_id.
 func collectAreaEntities(ctx context.Context, client homeassistant.Client, entityIDsInArea map[string]bool) []compactEntityState {
 	states, err := client.GetStates(ctx)
 	if err != nil {
@@ -493,12 +496,14 @@ func collectAreaEntities(ctx context.Context, client homeassistant.Client, entit
 		}
 		result = append(result, entry)
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].EntityID < result[j].EntityID
+	slices.SortFunc(result, func(a, b compactEntityState) int {
+		return cmp.Compare(a.EntityID, b.EntityID)
 	})
 	return result
 }
 
+// findAssignedAutomations returns automations directly assigned to the area via
+// entity registry area_id (automation.* entries whose AreaID == areaID).
 // findAssignedAutomations returns automations directly assigned to the area via
 // entity registry area_id (automation.* entries whose AreaID == areaID).
 func findAssignedAutomations(ctx context.Context, client homeassistant.Client, areaID string) []areaAssignedAutomation {
@@ -532,8 +537,8 @@ func findAssignedAutomations(ctx context.Context, client homeassistant.Client, a
 			State:        a.State,
 		})
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].EntityID < result[j].EntityID
+	slices.SortFunc(result, func(a, b areaAssignedAutomation) int {
+		return cmp.Compare(a.EntityID, b.EntityID)
 	})
 	return result
 }

--- a/internal/handlers/automations.go
+++ b/internal/handlers/automations.go
@@ -2,11 +2,12 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -298,8 +299,8 @@ func (h *AutomationHandlers) handleList(ctx context.Context, client homeassistan
 
 // sortAutomationsByEntityID sorts automations by entity_id for stable pagination.
 func sortAutomationsByEntityID(automations []homeassistant.Automation) {
-	sort.Slice(automations, func(i, j int) bool {
-		return automations[i].EntityID < automations[j].EntityID
+	slices.SortFunc(automations, func(a, b homeassistant.Automation) int {
+		return cmp.Compare(a.EntityID, b.EntityID)
 	})
 }
 

--- a/internal/handlers/automations_coverage.go
+++ b/internal/handlers/automations_coverage.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -265,8 +267,8 @@ func buildCoverageAreaStats(
 	}
 
 	// Sort by area name
-	sort.Slice(areaStats, func(i, j int) bool {
-		return areaStats[i].AreaName < areaStats[j].AreaName
+	slices.SortFunc(areaStats, func(a, b AreaCoverageInfo) int {
+		return cmp.Compare(a.AreaName, b.AreaName)
 	})
 
 	return areaStats

--- a/internal/handlers/entities_consolidated.go
+++ b/internal/handlers/entities_consolidated.go
@@ -2,9 +2,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -178,22 +180,22 @@ func validateSortAndGroup(params stateFilterParams) error {
 func sortEntities(states []homeassistant.Entity, sortBy string) error {
 	switch sortBy {
 	case sortByEntityID:
-		sort.Slice(states, func(i, j int) bool {
-			return states[i].EntityID < states[j].EntityID
+		slices.SortFunc(states, func(a, b homeassistant.Entity) int {
+			return cmp.Compare(a.EntityID, b.EntityID)
 		})
 	case sortByState:
-		sort.Slice(states, func(i, j int) bool {
-			return states[i].State < states[j].State
+		slices.SortFunc(states, func(a, b homeassistant.Entity) int {
+			return cmp.Compare(a.State, b.State)
 		})
 	case sortByLastChanged:
-		sort.Slice(states, func(i, j int) bool {
-			return states[i].LastChanged.Before(states[j].LastChanged)
+		slices.SortFunc(states, func(a, b homeassistant.Entity) int {
+			return a.LastChanged.Compare(b.LastChanged)
 		})
 	case sortByFriendlyName:
-		sort.Slice(states, func(i, j int) bool {
-			nameI := formatter.GetFriendlyName(states[i].EntityID, states[i].Attributes)
-			nameJ := formatter.GetFriendlyName(states[j].EntityID, states[j].Attributes)
-			return strings.ToLower(nameI) < strings.ToLower(nameJ)
+		slices.SortFunc(states, func(a, b homeassistant.Entity) int {
+			nameA := formatter.GetFriendlyName(a.EntityID, a.Attributes)
+			nameB := formatter.GetFriendlyName(b.EntityID, b.Attributes)
+			return cmp.Compare(strings.ToLower(nameA), strings.ToLower(nameB))
 		})
 	default:
 		return fmt.Errorf("unsupported sort_by: %s", sortBy)
@@ -1286,8 +1288,8 @@ func (h *ConsolidatedEntityQueryHandlers) handleDomains(
 	}
 
 	// Sort by domain name
-	sort.Slice(domains, func(i, j int) bool {
-		return domains[i].Domain < domains[j].Domain
+	slices.SortFunc(domains, func(a, b domainInfo) int {
+		return cmp.Compare(a.Domain, b.Domain)
 	})
 
 	output, err := json.MarshalIndent(domains, "", "  ")

--- a/internal/handlers/entities_health.go
+++ b/internal/handlers/entities_health.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -367,11 +369,11 @@ func filterIssues(issues []HealthIssue, categories map[string]bool, domain strin
 }
 
 func sortIssues(issues []HealthIssue) {
-	sort.Slice(issues, func(i, j int) bool {
-		if issues[i].Category != issues[j].Category {
-			return issues[i].Category < issues[j].Category
-		}
-		return issues[i].EntityID < issues[j].EntityID
+	slices.SortFunc(issues, func(a, b HealthIssue) int {
+		return cmp.Or(
+			cmp.Compare(a.Category, b.Category),
+			cmp.Compare(a.EntityID, b.EntityID),
+		)
 	})
 }
 

--- a/internal/handlers/entities_presence.go
+++ b/internal/handlers/entities_presence.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -184,11 +186,11 @@ func sortPresenceResults(
 	trackersWithoutPerson *[]TrackerInfo,
 	personsWithoutTrackers *[]string,
 ) {
-	sort.Slice(*personInfos, func(i, j int) bool {
-		return (*personInfos)[i].Name < (*personInfos)[j].Name
+	slices.SortFunc(*personInfos, func(a, b PersonInfo) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
-	sort.Slice(*trackersWithoutPerson, func(i, j int) bool {
-		return (*trackersWithoutPerson)[i].Name < (*trackersWithoutPerson)[j].Name
+	slices.SortFunc(*trackersWithoutPerson, func(a, b TrackerInfo) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 	sort.Strings(*personsWithoutTrackers)
 }

--- a/internal/handlers/formatter/automations.go
+++ b/internal/handlers/formatter/automations.go
@@ -2,9 +2,11 @@
 package formatter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -228,11 +230,11 @@ func (f *NaturalAutomationFormatter) formatModeCounts(counts map[string]int) str
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Value != sorted[j].Value {
-			return sorted[i].Value > sorted[j].Value
-		}
-		return sorted[i].Key < sorted[j].Key
+	slices.SortFunc(sorted, func(a, b kv) int {
+		return cmp.Or(
+			cmp.Compare(b.Value, a.Value),
+			cmp.Compare(a.Key, b.Key),
+		)
 	})
 
 	var parts []string
@@ -252,10 +254,10 @@ func (f *NaturalAutomationFormatter) getRecentlyTriggered(automations []homeassi
 	}
 
 	// Sort by last_triggered descending
-	sort.Slice(triggered, func(i, j int) bool {
-		ti, _ := time.Parse(time.RFC3339, triggered[i].LastTriggered)
-		tj, _ := time.Parse(time.RFC3339, triggered[j].LastTriggered)
-		return ti.After(tj)
+	slices.SortFunc(triggered, func(a, b homeassistant.Automation) int {
+		ta, _ := time.Parse(time.RFC3339, a.LastTriggered)
+		tb, _ := time.Parse(time.RFC3339, b.LastTriggered)
+		return tb.Compare(ta)
 	})
 
 	if len(triggered) > limit {

--- a/internal/handlers/formatter/helpers.go
+++ b/internal/handlers/formatter/helpers.go
@@ -2,10 +2,11 @@
 package formatter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/zorak1103/ha-mcp/internal/homeassistant"
@@ -588,11 +589,11 @@ func (f *NaturalHelperFormatter) sortTypesByCount(counts map[string]int) []strin
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Value != sorted[j].Value {
-			return sorted[i].Value > sorted[j].Value
-		}
-		return sorted[i].Key < sorted[j].Key
+	slices.SortFunc(sorted, func(a, b kv) int {
+		return cmp.Or(
+			cmp.Compare(b.Value, a.Value),
+			cmp.Compare(a.Key, b.Key),
+		)
 	})
 
 	result := make([]string, 0, len(sorted))

--- a/internal/handlers/formatter/registry.go
+++ b/internal/handlers/formatter/registry.go
@@ -1,10 +1,11 @@
 package formatter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/zorak1103/ha-mcp/internal/homeassistant"
@@ -314,11 +315,11 @@ func writeSortedCounts(result *strings.Builder, counts map[string]int) {
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Value != sorted[j].Value {
-			return sorted[i].Value > sorted[j].Value
-		}
-		return sorted[i].Key < sorted[j].Key
+	slices.SortFunc(sorted, func(a, b kv) int {
+		return cmp.Or(
+			cmp.Compare(b.Value, a.Value),
+			cmp.Compare(a.Key, b.Key),
+		)
 	})
 
 	for _, kv := range sorted {

--- a/internal/handlers/formatter/scenes.go
+++ b/internal/handlers/formatter/scenes.go
@@ -1,9 +1,11 @@
 package formatter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -147,11 +149,11 @@ func (f *NaturalSceneFormatter) formatDomainCounts(counts map[string]int) string
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Value != sorted[j].Value {
-			return sorted[i].Value > sorted[j].Value
-		}
-		return sorted[i].Key < sorted[j].Key
+	slices.SortFunc(sorted, func(a, b kv) int {
+		return cmp.Or(
+			cmp.Compare(b.Value, a.Value),
+			cmp.Compare(a.Key, b.Key),
+		)
 	})
 
 	var parts []string

--- a/internal/handlers/formatter/scripts.go
+++ b/internal/handlers/formatter/scripts.go
@@ -2,10 +2,11 @@
 package formatter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -172,11 +173,11 @@ func (f *NaturalScriptFormatter) formatModeCounts(counts map[string]int) string 
 	for k, v := range counts {
 		sorted = append(sorted, kv{k, v})
 	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].Value != sorted[j].Value {
-			return sorted[i].Value > sorted[j].Value
-		}
-		return sorted[i].Key < sorted[j].Key
+	slices.SortFunc(sorted, func(a, b kv) int {
+		return cmp.Or(
+			cmp.Compare(b.Value, a.Value),
+			cmp.Compare(a.Key, b.Key),
+		)
 	})
 
 	var parts []string

--- a/internal/handlers/logbook_correlation.go
+++ b/internal/handlers/logbook_correlation.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -126,8 +126,8 @@ func fetchLogbookEntriesForCorrelation(
 	}
 
 	// Sort by timestamp
-	sort.Slice(allEntries, func(i, j int) bool {
-		return allEntries[i].Timestamp.Before(allEntries[j].Timestamp)
+	slices.SortFunc(allEntries, func(a, b correlationEntry) int {
+		return a.Timestamp.Compare(b.Timestamp)
 	})
 
 	return allEntries

--- a/internal/handlers/registry_consolidated.go
+++ b/internal/handlers/registry_consolidated.go
@@ -2,8 +2,10 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -162,8 +164,8 @@ func (h *ConsolidatedRegistryHandlers) handleEntities(
 	filter.buildDeviceIDsInArea(ctx, client)
 	filtered := filter.filterEntityRegistry(entries)
 
-	sort.Slice(filtered, func(i, j int) bool {
-		return filtered[i].EntityID < filtered[j].EntityID
+	slices.SortFunc(filtered, func(a, b homeassistant.EntityRegistryEntry) int {
+		return cmp.Compare(a.EntityID, b.EntityID)
 	})
 
 	filtersMap := buildEntityRegistryFiltersMap(filter)
@@ -250,8 +252,8 @@ func (h *ConsolidatedRegistryHandlers) handleDevices(
 	filter := parseDeviceRegistryFilter(args)
 	filtered := filterDeviceRegistry(entries, filter)
 
-	sort.Slice(filtered, func(i, j int) bool {
-		return filtered[i].ID < filtered[j].ID
+	slices.SortFunc(filtered, func(a, b homeassistant.DeviceRegistryEntry) int {
+		return cmp.Compare(a.ID, b.ID)
 	})
 
 	filtersMap := buildDeviceRegistryFiltersMap(filter)

--- a/internal/handlers/services.go
+++ b/internal/handlers/services.go
@@ -2,9 +2,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -157,8 +159,8 @@ func (h *ServiceHandlers) handleCompactServices(services []homeassistant.Service
 		})
 	}
 
-	sort.Slice(compact, func(i, j int) bool {
-		return compact[i].Domain < compact[j].Domain
+	slices.SortFunc(compact, func(a, b compactServiceEntry) int {
+		return cmp.Compare(a.Domain, b.Domain)
 	})
 
 	output, err := json.MarshalIndent(compact, "", "  ")


### PR DESCRIPTION
## Summary
- Replace all 23 `sort.Slice` call sites (across 15 files) with `slices.SortFunc` + `cmp.Compare`/`cmp.Or` (or `time.Time.Compare` where sorting by time) — the stdlib-recommended pattern since Go 1.21, already available given this module's `go 1.26` requirement. Behavior/ordering is unchanged; `sort` imports are dropped in files that no longer use any other `sort.*` function.
- Simplify `CreateAnalysisSnapshot`'s parallel registry fetch to use `sync.WaitGroup.Go` (Go 1.25) instead of manual `wg.Add`/`defer wg.Done()`, and drop the `sync.Mutex` guarding the writes — each of the 4 goroutines only ever writes a distinct `AnalysisSnapshot` field, so there was no actual shared state to protect.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `go vet ./...` (clean)
- [x] `task lint` (0 issues)
- [x] `task test` (all packages pass)
- [x] `task test:coverage` (86 passed, 0 failed, all files ≥80%)